### PR TITLE
[CHORE] #39 CORS 허용 도메인 추가

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/common/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/sseotdabwa/common/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:3000",
+                "http://localhost:5173",
                 "https://dev.buy-or-not.com",
                 "https://buy-or-not.com"
         ));


### PR DESCRIPTION
### 🚀 Issue Number
#39 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`chore/#39-cors` → `develop`

### 🔎 작업 내용
- Spring Security CORS 설정에 localhost:5173 허용 도메인 추가

### 🎯 테스트 결과
- 기존 허용 도메인 동작 영향 없음