### PR TITLE
[FEATURE] #42 VoteLog 초기 도메인 구조 추가

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/domain/votes/entity/VoteLog.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/votes/entity/VoteLog.java
@@ -1,0 +1,49 @@
+package com.nexters.sseotdabwa.domain.votes.entity;
+
+import com.nexters.sseotdabwa.common.entity.BaseEntity;
+import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+import com.nexters.sseotdabwa.domain.votes.enums.VoteChoice;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "vote_logs",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_vote_log_user_feed",
+                        columnNames = {"user_id", "feed_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VoteLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "choice", nullable = false, length = 10)
+    private VoteChoice choice;
+
+    @Builder
+    public VoteLog(User user, Feed feed, VoteChoice choice) {
+        this.user = user;
+        this.feed = feed;
+        this.choice = choice;
+    }
+}

--- a/src/main/java/com/nexters/sseotdabwa/domain/votes/enums/VoteChoice.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/votes/enums/VoteChoice.java
@@ -1,0 +1,5 @@
+package com.nexters.sseotdabwa.domain.votes.enums;
+
+public enum VoteChoice {
+    YES, NO
+}

--- a/src/main/java/com/nexters/sseotdabwa/domain/votes/repository/VoteLogRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/votes/repository/VoteLogRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.sseotdabwa.domain.votes.repository;
+
+import com.nexters.sseotdabwa.domain.votes.entity.VoteLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteLogRepository extends JpaRepository<VoteLog, Long> {
+}

--- a/src/main/java/com/nexters/sseotdabwa/domain/votes/service/VoteLogService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/votes/service/VoteLogService.java
@@ -1,0 +1,16 @@
+package com.nexters.sseotdabwa.domain.votes.service;
+
+import com.nexters.sseotdabwa.domain.votes.repository.VoteLogRepository;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteLogService {
+
+    private final VoteLogRepository voteLogRepository;
+}


### PR DESCRIPTION
### 🚀 Issue Number
#42 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#42-votelogs` → `develop`

### 🔎 작업 내용
- VoteLog(투표 로그) 도메인 구조 추가
  - `domain/votes`
    - Entity: `VoteLog`
    - 사용자(User) ↔ 피드(Feed) 투표 이력 기록
    - choice는 Enum(YES, NO) 로 관리
    - user_id + feed_id UNIQUE 제약으로 중복 투표 방지

### 🎯 테스트 결과
- 도메인/테이블/연관관계 중심 작업으로 별도 테스트 없음