### PR TITLE
[CHORE] #45 기본 프로필 이미지 URL을 실제 S3 URL로 교체

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/domain/users/enums/DefaultProfileImage.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/users/enums/DefaultProfileImage.java
@@ -8,18 +8,17 @@ import lombok.RequiredArgsConstructor;
 /**
  * 기본 프로필 이미지 목록
  * - 신규 회원 가입 시 랜덤으로 부여
- * - TODO: 실제 이미지 URL로 교체 필요
  */
 @Getter
 @RequiredArgsConstructor
 public enum DefaultProfileImage {
-    IMAGE_01("https://example.com/profiles/default_01.png"),
-    IMAGE_02("https://example.com/profiles/default_02.png"),
-    IMAGE_03("https://example.com/profiles/default_03.png"),
-    IMAGE_04("https://example.com/profiles/default_04.png"),
-    IMAGE_05("https://example.com/profiles/default_05.png"),
-    IMAGE_06("https://example.com/profiles/default_06.png"),
-    IMAGE_07("https://example.com/profiles/default_07.png");
+    IMAGE_01("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image1.png"),
+    IMAGE_02("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image2.png"),
+    IMAGE_03("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image3.png"),
+    IMAGE_04("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image4.png"),
+    IMAGE_05("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image5.png"),
+    IMAGE_06("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image6.png"),
+    IMAGE_07("https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image7.png");
 
     private final String url;
 


### PR DESCRIPTION
### 🚀 Issue Number
#45 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`chore/#45-image-url` → `develop`

### 🔎 작업 내용
  - DefaultProfileImage enum의 placeholder URL(example.com)을 실제 S3 URL로 교체
    - https://sseotdabwa-image.s3.ap-northeast-2.amazonaws.com/Profile_image{1~7}.png
  - 완료된 TODO 주석 제거

### 🎯 테스트 결과
- 기존 로직(랜덤 선택) 변경 없이 URL 값만 교체하여 동작에 영향 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 기본 프로필 이미지가 올바르게 로드되도록 수정했습니다. 7개의 기본 프로필 이미지가 정상적으로 표시되며, 사용자는 프로필 설정 시 모든 이미지 옵션을 제대로 확인하고 선택할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->