### PR TITLE
[FIX] # 96 GlobalExceptionHandlerTest JSON 직렬화 실패 수정

### DIFF
--- a/src/test/java/com/nexters/sseotdabwa/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/common/exception/GlobalExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +33,7 @@ class GlobalExceptionHandlerTest {
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new TestController())
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
                 .build();
     }
 


### PR DESCRIPTION
### 🚀 Issue Number
close #96

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`fix/#96-test-fail` → `develop`

### 🔎 작업 내용
- `GlobalExceptionHandlerTest`의 `MockMvcBuilders.standaloneSetup()`에 `MappingJackson2HttpMessageConverter`를 명시적으로 지정
- Spring Boot ApplicationContext 없이 독립 구성 시 `ApiResponse<Void>`가 JSON 객체로 직렬화되지 않던 문제 해결

### 🎯 테스트 결과
- 247 tests completed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 인프라 개선을 통해 JSON 메시지 변환 처리 강화

---

**참고:** 이 업데이트는 내부 테스트 개선 사항이며, 사용자에게 직접적인 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->