### PR TITLE
[FIX] #98 피드 커서 페이지네이션 정렬 기준을 id → createdAt으로 변경

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
@@ -31,21 +31,21 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     List<Feed> findByUserIdOrderByCreatedAtDesc(Long userId);
 
-    List<Feed> findByReportStatusNotOrderByIdDesc(ReportStatus reportStatus, Pageable pageable);
+    List<Feed> findByReportStatusNotOrderByCreatedAtDescIdDesc(ReportStatus reportStatus, Pageable pageable);
 
-    List<Feed> findByIdLessThanAndReportStatusNotOrderByIdDesc(Long id, ReportStatus reportStatus, Pageable pageable);
+    List<Feed> findByIdLessThanAndReportStatusNotOrderByCreatedAtDescIdDesc(Long id, ReportStatus reportStatus, Pageable pageable);
 
-    List<Feed> findByFeedStatusAndReportStatusNotOrderByIdDesc(FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
+    List<Feed> findByFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
 
-    List<Feed> findByIdLessThanAndFeedStatusAndReportStatusNotOrderByIdDesc(Long id, FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
+    List<Feed> findByIdLessThanAndFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(Long id, FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
 
-    List<Feed> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    List<Feed> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
 
-    List<Feed> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long id, Pageable pageable);
+    List<Feed> findByUserIdAndIdLessThanOrderByCreatedAtDescIdDesc(Long userId, Long id, Pageable pageable);
 
-    List<Feed> findByUserIdAndFeedStatusOrderByIdDesc(Long userId, FeedStatus feedStatus, Pageable pageable);
+    List<Feed> findByUserIdAndFeedStatusOrderByCreatedAtDescIdDesc(Long userId, FeedStatus feedStatus, Pageable pageable);
 
-    List<Feed> findByUserIdAndIdLessThanAndFeedStatusOrderByIdDesc(Long userId, Long id, FeedStatus feedStatus, Pageable pageable);
+    List<Feed> findByUserIdAndIdLessThanAndFeedStatusOrderByCreatedAtDescIdDesc(Long userId, Long id, FeedStatus feedStatus, Pageable pageable);
 
     @Modifying
     @Query("UPDATE Feed f SET f.feedStatus = 'CLOSED', f.updatedAt = :now WHERE f.feedStatus = 'OPEN' AND f.createdAt < :cutoff")

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -103,14 +103,14 @@ public class FeedService {
         Pageable pageable = PageRequest.ofSize(size + 1);
         if (feedStatus != null) {
             if (cursor == null) {
-                return feedRepository.findByFeedStatusAndReportStatusNotOrderByIdDesc(feedStatus, ReportStatus.DELETED, pageable);
+                return feedRepository.findByFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(feedStatus, ReportStatus.DELETED, pageable);
             }
-            return feedRepository.findByIdLessThanAndFeedStatusAndReportStatusNotOrderByIdDesc(cursor, feedStatus, ReportStatus.DELETED, pageable);
+            return feedRepository.findByIdLessThanAndFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(cursor, feedStatus, ReportStatus.DELETED, pageable);
         }
         if (cursor == null) {
-            return feedRepository.findByReportStatusNotOrderByIdDesc(ReportStatus.DELETED, pageable);
+            return feedRepository.findByReportStatusNotOrderByCreatedAtDescIdDesc(ReportStatus.DELETED, pageable);
         }
-        return feedRepository.findByIdLessThanAndReportStatusNotOrderByIdDesc(cursor, ReportStatus.DELETED, pageable);
+        return feedRepository.findByIdLessThanAndReportStatusNotOrderByCreatedAtDescIdDesc(cursor, ReportStatus.DELETED, pageable);
     }
 
     public List<Feed> findByUserIdOrderByCreatedAtDesc(Long userId) {
@@ -121,14 +121,14 @@ public class FeedService {
         Pageable pageable = PageRequest.ofSize(size + 1);
         if (feedStatus != null) {
             if (cursor == null) {
-                return feedRepository.findByUserIdAndFeedStatusOrderByIdDesc(userId, feedStatus, pageable);
+                return feedRepository.findByUserIdAndFeedStatusOrderByCreatedAtDescIdDesc(userId, feedStatus, pageable);
             }
-            return feedRepository.findByUserIdAndIdLessThanAndFeedStatusOrderByIdDesc(userId, cursor, feedStatus, pageable);
+            return feedRepository.findByUserIdAndIdLessThanAndFeedStatusOrderByCreatedAtDescIdDesc(userId, cursor, feedStatus, pageable);
         }
         if (cursor == null) {
-            return feedRepository.findByUserIdOrderByIdDesc(userId, pageable);
+            return feedRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId, pageable);
         }
-        return feedRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, cursor, pageable);
+        return feedRepository.findByUserIdAndIdLessThanOrderByCreatedAtDescIdDesc(userId, cursor, pageable);
     }
 
     @Transactional

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
@@ -274,7 +274,7 @@ class FeedServiceTest {
 
         // then
         assertThat(result).hasSize(3); // size+1 = 3건 조회
-        assertThat(result.get(0).getId()).isGreaterThan(result.get(1).getId()); // ID 내림차순
+        assertThat(result.get(0).getId()).isGreaterThan(result.get(1).getId()); // 최신순(createdAt DESC, id DESC)
     }
 
     @Test
@@ -430,7 +430,7 @@ class FeedServiceTest {
 
         // then
         assertThat(result).hasSize(3); // size+1 = 3건 조회
-        assertThat(result.get(0).getId()).isGreaterThan(result.get(1).getId()); // ID 내림차순
+        assertThat(result.get(0).getId()).isGreaterThan(result.get(1).getId()); // 최신순(createdAt DESC, id DESC)
     }
 
     @Test


### PR DESCRIPTION
### 🚀 Issue Number
#98

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`fix/#98-feed-list` → `develop`

### 🔎 작업 내용
피드 커서 페이지네이션 정렬 기준을 `id DESC`에서 `createdAt DESC, id DESC`로 변경

- `FeedRepository`: 커서 페이지네이션 관련 8개 메서드명 변경
  - `OrderByIdDesc` → `OrderByCreatedAtDescIdDesc`
  - 동일 `createdAt`을 가진 피드는 `id DESC`로 보조 정렬하여 안정적인 순서 보장
- `FeedService`: 변경된 Repository 메서드 호출부 업데이트
- API 계약 변경 없음 (cursor 타입, 응답 구조 동일)

### 🎯 테스트 결과
- 기존 커서 페이지네이션 테스트 전체 통과
- 정렬 기준 관련 주석 수정 (`ID 내림차순` → `최신순(createdAt DESC, id DESC)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 피드 정렬 방식을 개선하여 사용자 경험을 향상시켰습니다. 피드 목록이 이제 생성 날짜 기준으로 최신순 정렬되어 사용자가 가장 최근에 작성된 콘텐츠를 우선적으로 확인할 수 있습니다. 정확히 같은 시간에 생성된 피드는 고유 ID를 기준으로 정렬되어 일관되고 예측 가능한 순서를 유지합니다. 이 개선사항은 모든 피드 조회 및 필터링 화면에 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->