### PR TITLE
[FEATURE] #103 피드 생성 API 이미지 업로드 1장 → 최대 3장으로 확장

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-80.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-80.7%25-brightgreen)
 # Sseotdabwa-BE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-80.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.0%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpecV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpecV2.java
@@ -1,0 +1,71 @@
+package com.nexters.sseotdabwa.api.feeds.controller;
+
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequestV2;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateResponse;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
+import com.nexters.sseotdabwa.common.response.ApiResponse;
+import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Feeds V2", description = "피드 API V2 (다중 이미지 지원)")
+public interface FeedControllerSpecV2 {
+
+    @Operation(
+            summary = "피드(투표) 등록 V2",
+            description = """
+                    피드(투표) 등록 API V2입니다.
+
+                    - 필수 입력: category, price, s3ObjectKeys (1~3장), imageWidth, imageHeight
+                    - 이미지는 Presigned URL 업로드 방식이며, 업로드 완료된 s3ObjectKey 목록을 받습니다.
+                    """,
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "피드 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 (필수값 누락/정책 위반)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ApiResponse<FeedCreateResponse> createFeed(
+            @Parameter(hidden = true) User user,
+            @Valid @RequestBody FeedCreateRequestV2 request
+    );
+
+    @Operation(
+            summary = "피드 리스트 조회 V2",
+            description = "커서 기반 페이지네이션으로 피드 리스트를 조회합니다. 다중 이미지(imageUrls)를 반환합니다. 비로그인 유저도 접근 가능하며, 로그인 시 투표 상태가 포함됩니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "피드 리스트 조회 성공")
+    })
+    ApiResponse<CursorPageResponse<FeedResponseV2>> getFeedList(
+            @Parameter(hidden = true) User user,
+            @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+    );
+
+    @Operation(
+            summary = "피드 단건 조회 V2",
+            description = "피드 ID로 단건 조회합니다. 다중 이미지(imageUrls)를 반환합니다. 비로그인 유저도 접근 가능하며, 로그인 시 투표 상태가 포함됩니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "피드 단건 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "피드를 찾을 수 없음")
+    })
+    ApiResponse<FeedResponseV2> getFeedDetail(
+            @Parameter(hidden = true) User user,
+            @PathVariable Long feedId
+    );
+}

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerV2.java
@@ -1,0 +1,57 @@
+package com.nexters.sseotdabwa.api.feeds.controller;
+
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequestV2;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateResponse;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
+import com.nexters.sseotdabwa.api.feeds.facade.FeedFacade;
+import com.nexters.sseotdabwa.common.response.ApiResponse;
+import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v2/feeds")
+@RequiredArgsConstructor
+public class FeedControllerV2 implements FeedControllerSpecV2 {
+
+    private final FeedFacade feedFacade;
+
+    @Override
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<FeedCreateResponse> createFeed(
+            @CurrentUser User user,
+            @Valid @RequestBody FeedCreateRequestV2 request
+    ) {
+        FeedCreateResponse response = feedFacade.createFeedV2(user, request);
+        return ApiResponse.success(response, HttpStatus.CREATED);
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<CursorPageResponse<FeedResponseV2>> getFeedList(
+            @CurrentUser User user,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) FeedStatus feedStatus
+    ) {
+        CursorPageResponse<FeedResponseV2> response = feedFacade.getFeedListV2(user, cursor, size, feedStatus);
+        return ApiResponse.success(response, HttpStatus.OK);
+    }
+
+    @Override
+    @GetMapping("/{feedId}")
+    public ApiResponse<FeedResponseV2> getFeedDetail(
+            @CurrentUser User user,
+            @PathVariable Long feedId
+    ) {
+        FeedResponseV2 response = feedFacade.getFeedDetailV2(user, feedId);
+        return ApiResponse.success(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequest.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequest.java
@@ -3,6 +3,8 @@ package com.nexters.sseotdabwa.api.feeds.dto;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import jakarta.validation.constraints.*;
 
+import java.util.List;
+
 public record FeedCreateRequest(
 
         @NotNull(message = "카테고리는 필수입니다.")
@@ -15,8 +17,9 @@ public record FeedCreateRequest(
         @Size(max = 100, message = "내용은 100자 이하로 입력해주세요.")
         String content,
 
-        @NotBlank(message = "이미지 s3ObjectKey는 필수입니다.")
-        String s3ObjectKey,
+        @NotEmpty(message = "이미지는 최소 1장 필요합니다.")
+        @Size(max = 3, message = "이미지는 최대 3장까지 가능합니다.")
+        List<String> s3ObjectKeys,
 
         @NotNull(message = "이미지 너비는 필수입니다.")
         @Positive(message = "이미지 너비는 1 이상이어야 합니다.")

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequestV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequestV2.java
@@ -3,7 +3,9 @@ package com.nexters.sseotdabwa.api.feeds.dto;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import jakarta.validation.constraints.*;
 
-public record FeedCreateRequest(
+import java.util.List;
+
+public record FeedCreateRequestV2(
 
         @NotNull(message = "카테고리는 필수입니다.")
         FeedCategory category,
@@ -15,8 +17,9 @@ public record FeedCreateRequest(
         @Size(max = 100, message = "내용은 100자 이하로 입력해주세요.")
         String content,
 
-        @NotBlank(message = "이미지 s3ObjectKey는 필수입니다.")
-        String s3ObjectKey,
+        @NotEmpty(message = "이미지는 최소 1장 필요합니다.")
+        @Size(max = 3, message = "이미지는 최대 3장까지 가능합니다.")
+        List<String> s3ObjectKeys,
 
         @NotNull(message = "이미지 너비는 필수입니다.")
         @Positive(message = "이미지 너비는 1 이상이어야 합니다.")

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponse.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponse.java
@@ -1,6 +1,7 @@
 package com.nexters.sseotdabwa.api.feeds.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.entity.FeedImage;
@@ -17,8 +18,8 @@ public record FeedResponse(
         Long noCount,
         Long totalCount,
         FeedStatus feedStatus,
-        String s3ObjectKey,
-        String viewUrl,
+        List<String> s3ObjectKeys,
+        List<String> imageUrls,
         Integer imageWidth,
         Integer imageHeight,
         FeedAuthorResponse author,
@@ -33,7 +34,7 @@ public record FeedResponse(
             String profileImage
     ) {}
 
-    public static FeedResponse of(Feed feed, FeedImage feedImage, String viewUrl) {
+    public static FeedResponse of(Feed feed, List<FeedImage> images, List<String> viewUrls) {
         return new FeedResponse(
                 feed.getId(),
                 feed.getContent(),
@@ -43,8 +44,8 @@ public record FeedResponse(
                 feed.getNoCount(),
                 feed.getYesCount() + feed.getNoCount(),
                 feed.getFeedStatus(),
-                feedImage != null ? feedImage.getS3ObjectKey() : null,
-                viewUrl,
+                images.stream().map(FeedImage::getS3ObjectKey).toList(),
+                viewUrls,
                 feed.getImageWidth(),
                 feed.getImageHeight(),
                 new FeedAuthorResponse(
@@ -58,7 +59,7 @@ public record FeedResponse(
         );
     }
 
-    public static FeedResponse of(Feed feed, FeedImage feedImage, String viewUrl, Boolean hasVoted, VoteChoice myVoteChoice) {
+    public static FeedResponse of(Feed feed, List<FeedImage> images, List<String> viewUrls, Boolean hasVoted, VoteChoice myVoteChoice) {
         return new FeedResponse(
                 feed.getId(),
                 feed.getContent(),
@@ -68,8 +69,8 @@ public record FeedResponse(
                 feed.getNoCount(),
                 feed.getYesCount() + feed.getNoCount(),
                 feed.getFeedStatus(),
-                feedImage != null ? feedImage.getS3ObjectKey() : null,
-                viewUrl,
+                images.stream().map(FeedImage::getS3ObjectKey).toList(),
+                viewUrls,
                 feed.getImageWidth(),
                 feed.getImageHeight(),
                 new FeedAuthorResponse(

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponseV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponseV2.java
@@ -1,6 +1,7 @@
 package com.nexters.sseotdabwa.api.feeds.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.entity.FeedImage;
@@ -8,7 +9,7 @@ import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.votes.enums.VoteChoice;
 
-public record FeedResponse(
+public record FeedResponseV2(
         Long feedId,
         String content,
         Long price,
@@ -17,8 +18,8 @@ public record FeedResponse(
         Long noCount,
         Long totalCount,
         FeedStatus feedStatus,
-        String s3ObjectKey,
-        String viewUrl,
+        List<String> s3ObjectKeys,
+        List<String> imageUrls,
         Integer imageWidth,
         Integer imageHeight,
         FeedAuthorResponse author,
@@ -33,8 +34,8 @@ public record FeedResponse(
             String profileImage
     ) {}
 
-    public static FeedResponse of(Feed feed, FeedImage feedImage, String viewUrl) {
-        return new FeedResponse(
+    public static FeedResponseV2 of(Feed feed, List<FeedImage> images, List<String> viewUrls) {
+        return new FeedResponseV2(
                 feed.getId(),
                 feed.getContent(),
                 feed.getPrice(),
@@ -43,8 +44,8 @@ public record FeedResponse(
                 feed.getNoCount(),
                 feed.getYesCount() + feed.getNoCount(),
                 feed.getFeedStatus(),
-                feedImage != null ? feedImage.getS3ObjectKey() : null,
-                viewUrl,
+                images.stream().map(FeedImage::getS3ObjectKey).toList(),
+                viewUrls,
                 feed.getImageWidth(),
                 feed.getImageHeight(),
                 new FeedAuthorResponse(
@@ -58,8 +59,8 @@ public record FeedResponse(
         );
     }
 
-    public static FeedResponse of(Feed feed, FeedImage feedImage, String viewUrl, Boolean hasVoted, VoteChoice myVoteChoice) {
-        return new FeedResponse(
+    public static FeedResponseV2 of(Feed feed, List<FeedImage> images, List<String> viewUrls, Boolean hasVoted, VoteChoice myVoteChoice) {
+        return new FeedResponseV2(
                 feed.getId(),
                 feed.getContent(),
                 feed.getPrice(),
@@ -68,8 +69,8 @@ public record FeedResponse(
                 feed.getNoCount(),
                 feed.getYesCount() + feed.getNoCount(),
                 feed.getFeedStatus(),
-                feedImage != null ? feedImage.getS3ObjectKey() : null,
-                viewUrl,
+                images.stream().map(FeedImage::getS3ObjectKey).toList(),
+                viewUrls,
                 feed.getImageWidth(),
                 feed.getImageHeight(),
                 new FeedAuthorResponse(

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
@@ -65,14 +65,14 @@ public class FeedFacade {
                 request.category(),
                 request.imageWidth(),
                 request.imageHeight(),
-                request.s3ObjectKey()
+                request.s3ObjectKeys()
         );
 
         // 1) Feed 저장
         Feed savedFeed = feedService.createFeed(command);
 
         // 2) FeedImage 저장
-        feedImageService.save(savedFeed, command.s3ObjectKey());
+        feedImageService.saveAll(savedFeed, command.s3ObjectKeys());
 
         return new FeedCreateResponse(savedFeed.getId());
     }
@@ -85,17 +85,18 @@ public class FeedFacade {
     @Transactional(readOnly = true)
     public FeedResponse getFeedDetail(User user, Long feedId) {
         Feed feed = feedService.findById(feedId);
-        FeedImage feedImage = feedImageService.findByFeed(feed).orElse(null);
-        String viewUrl = buildViewUrl(feedImage);
+
+        List<FeedImage> images = feedImageService.findByFeed(feed);
+        List<String> imageUrls = buildViewUrls(images);
 
         if (user == null) {
-            return FeedResponse.of(feed, feedImage, viewUrl);
+            return FeedResponse.of(feed, images, imageUrls);
         }
 
         List<VoteLog> voteLogs = voteLogService.findByUserIdAndFeedIds(user.getId(), List.of(feedId));
         VoteChoice myChoice = voteLogs.isEmpty() ? null : voteLogs.get(0).getChoice();
         boolean hasVoted = myChoice != null;
-        return FeedResponse.of(feed, feedImage, viewUrl, hasVoted, myChoice);
+        return FeedResponse.of(feed, images, imageUrls, hasVoted, myChoice);
     }
 
     /**
@@ -116,30 +117,32 @@ public class FeedFacade {
         boolean hasNext = feeds.size() > pageSize;
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
 
-        List<FeedImage> feedImages = feedImageService.findByFeeds(slicedFeeds);
-        Map<Long, FeedImage> imageMap = feedImages.stream()
-                .collect(Collectors.toMap(fi -> fi.getFeed().getId(), fi -> fi));
+        List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
+        List<FeedImage> images = feedImageService.findByFeedIds(feedIds);
+
+        Map<Long, List<FeedImage>> imageMap = images.stream()
+                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
 
         List<FeedResponse> content;
         if (user == null || slicedFeeds.isEmpty()) {
             content = slicedFeeds.stream()
                     .map(feed -> {
-                        FeedImage img = imageMap.get(feed.getId());
-                        return FeedResponse.of(feed, img, buildViewUrl(img));
+                        List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
+                        return FeedResponse.of(feed, imgs, buildViewUrls(imgs));
                     })
                     .toList();
         } else {
-            List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
             Map<Long, VoteChoice> voteMap = voteLogService.findByUserIdAndFeedIds(user.getId(), feedIds)
                     .stream()
                     .collect(Collectors.toMap(vl -> vl.getFeed().getId(), vl -> vl.getChoice()));
 
             content = slicedFeeds.stream()
                     .map(feed -> {
-                        FeedImage img = imageMap.get(feed.getId());
+                        List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
                         VoteChoice myChoice = voteMap.get(feed.getId());
                         boolean hasVoted = myChoice != null;
-                        return FeedResponse.of(feed, img, buildViewUrl(img), hasVoted, myChoice);
+
+                        return FeedResponse.of(feed, imgs, buildViewUrls(imgs), hasVoted, myChoice);
                     })
                     .toList();
         }
@@ -148,15 +151,14 @@ public class FeedFacade {
         return CursorPageResponse.of(content, nextCursor, hasNext);
     }
 
-    private String buildViewUrl(FeedImage feedImage) {
-        if (feedImage == null) {
-            return null;
-        }
-        String domain = awsProperties.cloudfront().domain();
-        if (domain.endsWith("/")) {
-            domain = domain.substring(0, domain.length() - 1);
-        }
-        return domain + "/" + feedImage.getS3ObjectKey();
+    private List<String> buildViewUrls(List<FeedImage> images) {
+        if (images == null || images.isEmpty()) return List.of();
+
+        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
+
+        return images.stream()
+                .map(img -> domain + "/" + img.getS3ObjectKey())
+                .toList();
     }
 
     /**
@@ -170,9 +172,9 @@ public class FeedFacade {
         }
 
         // S3 삭제를 위해 s3ObjectKey 미리 조회
-        String s3ObjectKey = feedImageService.findByFeed(feed)
+        List<String> s3Keys = feedImageService.findByFeed(feed).stream()
                 .map(FeedImage::getS3ObjectKey)
-                .orElse(null);
+                .toList();
 
         notificationService.deleteByFeed(feed);
         voteLogService.deleteByFeed(feed);
@@ -181,11 +183,11 @@ public class FeedFacade {
         feedService.delete(feed);
 
         // S3 오브젝트 삭제 (실패해도 DB 트랜잭션은 유지)
-        if (s3ObjectKey != null) {
+        for (String key : s3Keys) {
             try {
-                s3StorageService.deleteObject(s3ObjectKey);
+                s3StorageService.deleteObject(key);
             } catch (Exception e) {
-                log.warn("S3 오브젝트 삭제 실패. key={}", s3ObjectKey, e);
+                log.warn("S3 삭제 실패 key={}", key, e);
             }
         }
     }

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequest;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequestV2;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateResponse;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedResponse;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
 import com.nexters.sseotdabwa.common.config.AwsProperties;
 import com.nexters.sseotdabwa.common.exception.GlobalException;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
@@ -53,8 +55,12 @@ public class FeedFacade {
     private final UserBlockService userBlockService;
     private final AwsProperties awsProperties;
 
+    // ========================
+    // V1
+    // ========================
+
     /**
-     * 피드 생성 + 피드 이미지 저장
+     * 피드 생성 + 피드 이미지 저장 (V1: 단일 이미지)
      */
     @Transactional
     public FeedCreateResponse createFeed(User user, FeedCreateRequest request) {
@@ -65,44 +71,38 @@ public class FeedFacade {
                 request.category(),
                 request.imageWidth(),
                 request.imageHeight(),
-                request.s3ObjectKeys()
+                List.of(request.s3ObjectKey())
         );
 
-        // 1) Feed 저장
         Feed savedFeed = feedService.createFeed(command);
-
-        // 2) FeedImage 저장
         feedImageService.saveAll(savedFeed, command.s3ObjectKeys());
 
         return new FeedCreateResponse(savedFeed.getId());
     }
 
     /**
-     * 피드 단건 조회 (비로그인 가능)
-     * - 인증된 경우: 투표 상태(hasVoted, myVoteChoice) 포함
-     * - 비인증인 경우: 투표 상태 없음
+     * 피드 단건 조회 (V1: 첫 번째 이미지 단건 반환)
      */
     @Transactional(readOnly = true)
     public FeedResponse getFeedDetail(User user, Long feedId) {
         Feed feed = feedService.findById(feedId);
 
         List<FeedImage> images = feedImageService.findByFeed(feed);
-        List<String> imageUrls = buildViewUrls(images);
+        FeedImage firstImage = images.isEmpty() ? null : images.get(0);
+        String viewUrl = buildViewUrl(firstImage);
 
         if (user == null) {
-            return FeedResponse.of(feed, images, imageUrls);
+            return FeedResponse.of(feed, firstImage, viewUrl);
         }
 
         List<VoteLog> voteLogs = voteLogService.findByUserIdAndFeedIds(user.getId(), List.of(feedId));
         VoteChoice myChoice = voteLogs.isEmpty() ? null : voteLogs.get(0).getChoice();
         boolean hasVoted = myChoice != null;
-        return FeedResponse.of(feed, images, imageUrls, hasVoted, myChoice);
+        return FeedResponse.of(feed, firstImage, viewUrl, hasVoted, myChoice);
     }
 
     /**
-     * 피드 리스트 조회 (비로그인 가능, 커서 기반 페이지네이션)
-     * - 인증된 경우: 투표 상태(hasVoted, myVoteChoice) 포함
-     * - 비인증인 경우: 투표 상태 없음
+     * 피드 리스트 조회 (V1: 피드당 첫 번째 이미지 단건 반환, 커서 기반 페이지네이션)
      */
     @Transactional(readOnly = true)
     public CursorPageResponse<FeedResponse> getFeedList(User user, Long cursor, Integer size, FeedStatus feedStatus) {
@@ -120,15 +120,114 @@ public class FeedFacade {
         List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
         List<FeedImage> images = feedImageService.findByFeedIds(feedIds);
 
-        Map<Long, List<FeedImage>> imageMap = images.stream()
-                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
+        // 피드당 id 오름차순 첫 번째 이미지만 유지
+        Map<Long, FeedImage> firstImageMap = images.stream()
+                .collect(Collectors.toMap(
+                        fi -> fi.getFeed().getId(),
+                        fi -> fi,
+                        (a, b) -> a
+                ));
 
         List<FeedResponse> content;
         if (user == null || slicedFeeds.isEmpty()) {
             content = slicedFeeds.stream()
                     .map(feed -> {
+                        FeedImage img = firstImageMap.get(feed.getId());
+                        return FeedResponse.of(feed, img, buildViewUrl(img));
+                    })
+                    .toList();
+        } else {
+            Map<Long, VoteChoice> voteMap = voteLogService.findByUserIdAndFeedIds(user.getId(), feedIds)
+                    .stream()
+                    .collect(Collectors.toMap(vl -> vl.getFeed().getId(), vl -> vl.getChoice()));
+
+            content = slicedFeeds.stream()
+                    .map(feed -> {
+                        FeedImage img = firstImageMap.get(feed.getId());
+                        VoteChoice myChoice = voteMap.get(feed.getId());
+                        boolean hasVoted = myChoice != null;
+                        return FeedResponse.of(feed, img, buildViewUrl(img), hasVoted, myChoice);
+                    })
+                    .toList();
+        }
+
+        Long nextCursor = hasNext ? slicedFeeds.get(slicedFeeds.size() - 1).getId() : null;
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    // ========================
+    // V2
+    // ========================
+
+    /**
+     * 피드 생성 + 피드 이미지 저장 (V2: 최대 3장 다중 이미지)
+     */
+    @Transactional
+    public FeedCreateResponse createFeedV2(User user, FeedCreateRequestV2 request) {
+        FeedCreateCommand command = new FeedCreateCommand(
+                user,
+                request.content(),
+                request.price(),
+                request.category(),
+                request.imageWidth(),
+                request.imageHeight(),
+                request.s3ObjectKeys()
+        );
+
+        Feed savedFeed = feedService.createFeed(command);
+        feedImageService.saveAll(savedFeed, command.s3ObjectKeys());
+
+        return new FeedCreateResponse(savedFeed.getId());
+    }
+
+    /**
+     * 피드 단건 조회 (V2: 다중 이미지 반환)
+     */
+    @Transactional(readOnly = true)
+    public FeedResponseV2 getFeedDetailV2(User user, Long feedId) {
+        Feed feed = feedService.findById(feedId);
+
+        List<FeedImage> images = feedImageService.findByFeed(feed);
+        List<String> imageUrls = buildViewUrls(images);
+
+        if (user == null) {
+            return FeedResponseV2.of(feed, images, imageUrls);
+        }
+
+        List<VoteLog> voteLogs = voteLogService.findByUserIdAndFeedIds(user.getId(), List.of(feedId));
+        VoteChoice myChoice = voteLogs.isEmpty() ? null : voteLogs.get(0).getChoice();
+        boolean hasVoted = myChoice != null;
+        return FeedResponseV2.of(feed, images, imageUrls, hasVoted, myChoice);
+    }
+
+    /**
+     * 피드 리스트 조회 (V2: 다중 이미지 반환, 커서 기반 페이지네이션)
+     */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<FeedResponseV2> getFeedListV2(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+        int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
+
+        List<Long> excludedUserIds = (user != null)
+                ? userBlockService.findBlockedUserIds(user.getId())
+                : Collections.emptyList();
+
+        List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, excludedUserIds);
+
+        boolean hasNext = feeds.size() > pageSize;
+        List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
+
+        List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
+        List<FeedImage> images = feedImageService.findByFeedIds(feedIds);
+
+        Map<Long, List<FeedImage>> imageMap = images.stream()
+                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
+
+        List<FeedResponseV2> content;
+        if (user == null || slicedFeeds.isEmpty()) {
+            content = slicedFeeds.stream()
+                    .map(feed -> {
                         List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
-                        return FeedResponse.of(feed, imgs, buildViewUrls(imgs));
+                        return FeedResponseV2.of(feed, imgs, buildViewUrls(imgs));
                     })
                     .toList();
         } else {
@@ -141,8 +240,7 @@ public class FeedFacade {
                         List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
                         VoteChoice myChoice = voteMap.get(feed.getId());
                         boolean hasVoted = myChoice != null;
-
-                        return FeedResponse.of(feed, imgs, buildViewUrls(imgs), hasVoted, myChoice);
+                        return FeedResponseV2.of(feed, imgs, buildViewUrls(imgs), hasVoted, myChoice);
                     })
                     .toList();
         }
@@ -151,15 +249,9 @@ public class FeedFacade {
         return CursorPageResponse.of(content, nextCursor, hasNext);
     }
 
-    private List<String> buildViewUrls(List<FeedImage> images) {
-        if (images == null || images.isEmpty()) return List.of();
-
-        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
-
-        return images.stream()
-                .map(img -> domain + "/" + img.getS3ObjectKey())
-                .toList();
-    }
+    // ========================
+    // 공통 (V1/V2 공유)
+    // ========================
 
     /**
      * 피드 삭제 (물리 삭제 + S3 이미지 삭제)
@@ -171,7 +263,6 @@ public class FeedFacade {
             throw new GlobalException(FeedErrorCode.FEED_DELETE_FORBIDDEN);
         }
 
-        // S3 삭제를 위해 s3ObjectKey 미리 조회
         List<String> s3Keys = feedImageService.findByFeed(feed).stream()
                 .map(FeedImage::getS3ObjectKey)
                 .toList();
@@ -182,7 +273,6 @@ public class FeedFacade {
         feedReviewService.deleteByFeed(feed);
         feedService.delete(feed);
 
-        // S3 오브젝트 삭제 (실패해도 DB 트랜잭션은 유지)
         for (String key : s3Keys) {
             try {
                 s3StorageService.deleteObject(key);
@@ -205,5 +295,19 @@ public class FeedFacade {
             throw new GlobalException(FeedErrorCode.FEED_ALREADY_REPORTED);
         }
         feedService.report(feed);
+    }
+
+    private String buildViewUrl(FeedImage image) {
+        if (image == null) return null;
+        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
+        return domain + "/" + image.getS3ObjectKey();
+    }
+
+    private List<String> buildViewUrls(List<FeedImage> images) {
+        if (images == null || images.isEmpty()) return List.of();
+        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
+        return images.stream()
+                .map(img -> domain + "/" + img.getS3ObjectKey())
+                .toList();
     }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpecV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpecV2.java
@@ -1,0 +1,33 @@
+package com.nexters.sseotdabwa.api.users.controller;
+
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
+import com.nexters.sseotdabwa.common.response.ApiResponse;
+import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Users V2", description = "사용자 API V2")
+public interface UserControllerSpecV2 {
+
+    @Operation(
+            summary = "내가 작성한 피드 조회 V2",
+            description = "커서 기반 페이지네이션으로 현재 로그인한 사용자가 작성한 피드 목록을 조회합니다. 다중 이미지(imageUrls)를 반환합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ApiResponse<CursorPageResponse<FeedResponseV2>> getMyFeeds(
+            @Parameter(hidden = true) User user,
+            @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+    );
+}

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerV2.java
@@ -1,0 +1,33 @@
+package com.nexters.sseotdabwa.api.users.controller;
+
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
+import com.nexters.sseotdabwa.api.users.facade.UserFacade;
+import com.nexters.sseotdabwa.common.response.ApiResponse;
+import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v2/users")
+@RequiredArgsConstructor
+public class UserControllerV2 implements UserControllerSpecV2 {
+
+    private final UserFacade userFacade;
+
+    @Override
+    @GetMapping("/me/feeds")
+    public ApiResponse<CursorPageResponse<FeedResponseV2>> getMyFeeds(
+            @CurrentUser User user,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) FeedStatus feedStatus
+    ) {
+        CursorPageResponse<FeedResponseV2> response = userFacade.getMyFeedsV2(user, cursor, size, feedStatus);
+        return ApiResponse.success(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nexters.sseotdabwa.api.feeds.dto.FeedResponse;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
 import com.nexters.sseotdabwa.api.users.dto.UserResponse;
 import com.nexters.sseotdabwa.api.users.dto.UserWithdrawResponse;
 import com.nexters.sseotdabwa.common.config.AwsProperties;
@@ -99,8 +100,13 @@ public class UserFacade {
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
 
         List<FeedImage> feedImages = feedImageService.findByFeeds(slicedFeeds);
-        Map<Long, List<FeedImage>> imageMap = feedImages.stream()
-                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
+        // V1: 피드당 id 오름차순 첫 번째 이미지만 사용
+        Map<Long, FeedImage> firstImageMap = feedImages.stream()
+                .collect(Collectors.toMap(
+                        fi -> fi.getFeed().getId(),
+                        fi -> fi,
+                        (a, b) -> a
+                ));
 
         List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
         Map<Long, VoteChoice> voteMap = voteLogService.findByUserIdAndFeedIds(user.getId(), feedIds)
@@ -109,19 +115,11 @@ public class UserFacade {
 
         List<FeedResponse> content = slicedFeeds.stream()
                 .map(feed -> {
-                    List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
-
-                    List<String> viewUrls = buildViewUrls(imgs);
-
+                    FeedImage img = firstImageMap.get(feed.getId());
+                    String viewUrl = buildViewUrl(img);
                     VoteChoice myChoice = voteMap.get(feed.getId());
                     boolean hasVoted = myChoice != null;
-                    return FeedResponse.of(
-                            feed,
-                            imgs,
-                            viewUrls,
-                            hasVoted,
-                            myChoice
-                    );
+                    return FeedResponse.of(feed, img, viewUrl, hasVoted, myChoice);
                 })
                 .toList();
 
@@ -129,11 +127,50 @@ public class UserFacade {
         return CursorPageResponse.of(content, nextCursor, hasNext);
     }
 
+    /**
+     * 내 피드 조회 V2 (커서 기반 페이지네이션, 다중 이미지 반환)
+     */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<FeedResponseV2> getMyFeedsV2(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+        int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
+
+        List<Feed> feeds = feedService.findByUserIdWithCursor(user.getId(), cursor, pageSize, feedStatus);
+
+        boolean hasNext = feeds.size() > pageSize;
+        List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
+
+        List<FeedImage> feedImages = feedImageService.findByFeeds(slicedFeeds);
+        Map<Long, List<FeedImage>> imageMap = feedImages.stream()
+                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
+
+        List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
+        Map<Long, VoteChoice> voteMap = voteLogService.findByUserIdAndFeedIds(user.getId(), feedIds)
+                .stream()
+                .collect(Collectors.toMap(vl -> vl.getFeed().getId(), vl -> vl.getChoice()));
+
+        List<FeedResponseV2> content = slicedFeeds.stream()
+                .map(feed -> {
+                    List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
+                    List<String> imageUrls = buildViewUrls(imgs);
+                    VoteChoice myChoice = voteMap.get(feed.getId());
+                    boolean hasVoted = myChoice != null;
+                    return FeedResponseV2.of(feed, imgs, imageUrls, hasVoted, myChoice);
+                })
+                .toList();
+
+        Long nextCursor = hasNext ? slicedFeeds.get(slicedFeeds.size() - 1).getId() : null;
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    private String buildViewUrl(FeedImage image) {
+        if (image == null) return null;
+        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
+        return domain + "/" + image.getS3ObjectKey();
+    }
+
     private List<String> buildViewUrls(List<FeedImage> images) {
         if (images == null || images.isEmpty()) return List.of();
-
         final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
-
         return images.stream()
                 .map(img -> domain + "/" + img.getS3ObjectKey())
                 .toList();

--- a/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
@@ -99,8 +99,8 @@ public class UserFacade {
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
 
         List<FeedImage> feedImages = feedImageService.findByFeeds(slicedFeeds);
-        Map<Long, FeedImage> imageMap = feedImages.stream()
-                .collect(Collectors.toMap(fi -> fi.getFeed().getId(), fi -> fi));
+        Map<Long, List<FeedImage>> imageMap = feedImages.stream()
+                .collect(Collectors.groupingBy(fi -> fi.getFeed().getId()));
 
         List<Long> feedIds = slicedFeeds.stream().map(Feed::getId).toList();
         Map<Long, VoteChoice> voteMap = voteLogService.findByUserIdAndFeedIds(user.getId(), feedIds)
@@ -109,10 +109,19 @@ public class UserFacade {
 
         List<FeedResponse> content = slicedFeeds.stream()
                 .map(feed -> {
-                    FeedImage img = imageMap.get(feed.getId());
+                    List<FeedImage> imgs = imageMap.getOrDefault(feed.getId(), List.of());
+
+                    List<String> viewUrls = buildViewUrls(imgs);
+
                     VoteChoice myChoice = voteMap.get(feed.getId());
                     boolean hasVoted = myChoice != null;
-                    return FeedResponse.of(feed, img, buildViewUrl(img), hasVoted, myChoice);
+                    return FeedResponse.of(
+                            feed,
+                            imgs,
+                            viewUrls,
+                            hasVoted,
+                            myChoice
+                    );
                 })
                 .toList();
 
@@ -120,15 +129,14 @@ public class UserFacade {
         return CursorPageResponse.of(content, nextCursor, hasNext);
     }
 
-    private String buildViewUrl(FeedImage feedImage) {
-        if (feedImage == null) {
-            return null;
-        }
-        String domain = awsProperties.cloudfront().domain();
-        if (domain.endsWith("/")) {
-            domain = domain.substring(0, domain.length() - 1);
-        }
-        return domain + "/" + feedImage.getS3ObjectKey();
+    private List<String> buildViewUrls(List<FeedImage> images) {
+        if (images == null || images.isEmpty()) return List.of();
+
+        final String domain = awsProperties.cloudfront().domain().replaceAll("/$", "");
+
+        return images.stream()
+                .map(img -> domain + "/" + img.getS3ObjectKey())
+                .toList();
     }
 
     /**

--- a/src/main/java/com/nexters/sseotdabwa/common/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/sseotdabwa/common/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 "/api/v1/auth/refresh"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/feeds", "/api/v1/feeds/", "/api/v1/feeds/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v2/feeds", "/api/v2/feeds/", "/api/v2/feeds/*").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/feeds/*/votes/guest").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/pre-launch/emails").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/entity/FeedImage.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/entity/FeedImage.java
@@ -17,8 +17,8 @@ public class FeedImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "feed_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
 
     @Column(name = "s3_object_key", nullable = false, length = 255)

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
@@ -19,7 +19,8 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "FEED_003", "피드를 찾을 수 없습니다."),
     FEED_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "FEED_004", "본인의 피드만 삭제할 수 있습니다."),
     FEED_ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "FEED_005", "이미 신고된 피드입니다."),
-    FEED_SELF_REPORT(HttpStatus.BAD_REQUEST, "FEED_006", "본인의 피드는 신고할 수 없습니다.");
+    FEED_SELF_REPORT(HttpStatus.BAD_REQUEST, "FEED_006", "본인의 피드는 신고할 수 없습니다."),
+    FEED_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "FEED_007", "이미지는 최대 3장까지 업로드할 수 있습니다." );
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
@@ -24,6 +24,7 @@ public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
         from FeedImage fi
         join fetch fi.feed f
         where f.id in :feedIds
+        order by fi.id asc
     """)
     List<FeedImage> findByFeedIds(@Param("feedIds") List<Long> feedIds);
 }

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
@@ -13,9 +13,9 @@ public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
 
     void deleteByFeedIn(List<Feed> feeds);
 
-    List<FeedImage> findByFeedIn(List<Feed> feeds);
+    List<FeedImage> findByFeedInOrderByIdAsc(List<Feed> feeds);
 
-    List<FeedImage> findByFeed(Feed feed);
+    List<FeedImage> findByFeedOrderByIdAsc(Feed feed);
 
     void deleteByFeed(Feed feed);
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedImageRepository.java
@@ -15,7 +15,7 @@ public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
 
     List<FeedImage> findByFeedIn(List<Feed> feeds);
 
-    Optional<FeedImage> findByFeed(Feed feed);
+    List<FeedImage> findByFeed(Feed feed);
 
     void deleteByFeed(Feed feed);
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageService.java
@@ -40,11 +40,11 @@ public class FeedImageService {
     }
 
     public List<FeedImage> findByFeed(Feed feed) {
-        return feedImageRepository.findByFeed(feed);
+        return feedImageRepository.findByFeedOrderByIdAsc(feed);
     }
 
     public List<FeedImage> findByFeeds(List<Feed> feeds) {
-        return feedImageRepository.findByFeedIn(feeds);
+        return feedImageRepository.findByFeedInOrderByIdAsc(feeds);
     }
 
     @Transactional

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageService.java
@@ -23,13 +23,15 @@ public class FeedImageService {
      * Feed : FeedImage = 1 : 1 저장
      */
     @Transactional
-    public void save(Feed feed, String s3ObjectKey) {
-        FeedImage feedImage = FeedImage.builder()
-                .feed(feed)
-                .s3ObjectKey(s3ObjectKey.trim())
-                .build();
+    public void saveAll(Feed feed, List<String> s3ObjectKeys) {
+        List<FeedImage> images = s3ObjectKeys.stream()
+                .map(key -> FeedImage.builder()
+                        .feed(feed)
+                        .s3ObjectKey(key.trim())
+                        .build())
+                .toList();
 
-        feedImageRepository.save(feedImage);
+        feedImageRepository.saveAll(images);
     }
 
     @Transactional
@@ -37,7 +39,7 @@ public class FeedImageService {
         feedImageRepository.deleteByFeedIn(feeds);
     }
 
-    public Optional<FeedImage> findByFeed(Feed feed) {
+    public List<FeedImage> findByFeed(Feed feed) {
         return feedImageRepository.findByFeed(feed);
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -69,8 +69,12 @@ public class FeedService {
         }
 
         // image
-        if (command.s3ObjectKey() == null || command.s3ObjectKey().isBlank()) {
+        if (command.s3ObjectKeys() == null || command.s3ObjectKeys().isEmpty()) {
             throw new GlobalException(FeedErrorCode.FEED_IMAGE_REQUIRED);
+        }
+
+        if (command.s3ObjectKeys().size() > 3) {
+            throw new GlobalException(FeedErrorCode.FEED_IMAGE_LIMIT_EXCEEDED);
         }
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -61,20 +61,26 @@ public class FeedService {
      * - Bean Validation 이후, 도메인 레벨에서 최종 방어
      */
     private void validate(FeedCreateCommand command) {
-        // content
+        // 1. content 길이 검증
         String content = normalizeContent(command.content());
-
         if (content.length() > MAX_CONTENT_LENGTH) {
             throw new GlobalException(FeedErrorCode.FEED_CONTENT_TOO_LONG);
         }
 
-        // image
+        // 2. 이미지 리스트 자체 검증 (null 또는 비어있음)
         if (command.s3ObjectKeys() == null || command.s3ObjectKeys().isEmpty()) {
             throw new GlobalException(FeedErrorCode.FEED_IMAGE_REQUIRED);
         }
 
+        // 3. 이미지 개수 제한 검증 (최대 3장)
         if (command.s3ObjectKeys().size() > 3) {
             throw new GlobalException(FeedErrorCode.FEED_IMAGE_LIMIT_EXCEEDED);
+        }
+
+        // 4. 이미지 원소 내부 검증 (원소가 null이거나 공백만 있는 경우 방지)
+        // 리스트 내 단 하나라도 유효하지 않은 키가 있다면 예외를 던집니다.
+        if (command.s3ObjectKeys().stream().anyMatch(key -> key == null || key.isBlank())) {
+            throw new GlobalException(FeedErrorCode.FEED_IMAGE_REQUIRED);
         }
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/command/FeedCreateCommand.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/command/FeedCreateCommand.java
@@ -3,6 +3,8 @@ package com.nexters.sseotdabwa.domain.feeds.service.command;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
+import java.util.List;
+
 public record FeedCreateCommand(
         User user,
         String content,
@@ -10,6 +12,6 @@ public record FeedCreateCommand(
         FeedCategory category,
         Integer imageWidth,
         Integer imageHeight,
-        String s3ObjectKey
+        List<String> s3ObjectKeys
 ) {
 }

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -4,6 +4,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -67,22 +69,17 @@ class FeedControllerTest {
     // ===== 피드 등록 =====
 
     @Test
-    @DisplayName("피드 등록 성공 - 201 Created 및 feedId 반환")
-    void createFeed_success() throws Exception {
+    @DisplayName("피드 등록 성공 - 이미지 1개 등록")
+    void createFeed_success_single_image() throws Exception {
         // given
-        User user = userRepository.save(User.builder()
-                .socialId(UUID.randomUUID().toString())
-                .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
-                .socialAccount(SocialAccount.KAKAO)
-                .build());
-
+        User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
 
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.valueOf("FOOD"),
+                FeedCategory.FOOD,
                 8000L,
                 "두쫀쿠 맛있어보이는데 살까 말까",
-                "feeds/uuid_test.jpg",
+                List.of("feeds/image1.jpg"), // 리스트로 변경
                 1080,
                 1350
         );
@@ -93,47 +90,45 @@ class FeedControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.feedId").exists())
-                .andExpect(jsonPath("$.status").value("201"));
+                .andExpect(jsonPath("$.data.feedId").exists());
     }
 
     @Test
-    @DisplayName("피드 등록 실패 - 인증 없으면 401")
-    void createFeed_unauthorized() throws Exception {
+    @DisplayName("피드 등록 성공 - 이미지 3개(최대) 등록")
+    void createFeed_success_max_images() throws Exception {
         // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.valueOf("FOOD"),
+                FeedCategory.FOOD,
                 8000L,
-                "두쫀쿠 맛있어보이는데 살까 말까",
-                "feeds/uuid_test.jpg",
+                "이미지 3개 테스트",
+                List.of("feeds/1.jpg", "feeds/2.jpg", "feeds/3.jpg"),
                 1080,
                 1350
         );
 
         // when & then
         mockMvc.perform(post("/api/v1/feeds")
+                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isCreated());
     }
 
     @Test
-    @DisplayName("피드 등록 실패 - s3ObjectKey blank면 400")
-    void createFeed_invalid_s3ObjectKey_blank_returns400() throws Exception {
+    @DisplayName("피드 등록 실패 - 이미지 0개면 400 (NotEmpty)")
+    void createFeed_invalid_image_empty_returns400() throws Exception {
         // given
-        User user = userRepository.save(User.builder()
-                .socialId(UUID.randomUUID().toString())
-                .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
-                .socialAccount(SocialAccount.KAKAO)
-                .build());
-
+        User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
 
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.valueOf("FOOD"),
+                FeedCategory.FOOD,
                 8000L,
-                "두쫀쿠 맛있어보이는데 살까 말까",
-                "   ", // @NotBlank
+                "이미지 없음",
+                Collections.emptyList(), // @NotEmpty 검증 대상
                 1080,
                 1350
         );
@@ -145,27 +140,44 @@ class FeedControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+    }
+
+    @Test
+    @DisplayName("피드 등록 실패 - 이미지 4개 이상이면 400 (Size)")
+    void createFeed_invalid_image_too_many_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequest request = new FeedCreateRequest(
+                FeedCategory.FOOD,
+                8000L,
+                "이미지 4개",
+                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg"), // @Size(max=3)
+                1080,
+                1350
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("피드 등록 실패 - content 100자 초과면 400")
     void createFeed_invalid_content_tooLong_returns400() throws Exception {
         // given
-        User user = userRepository.save(User.builder()
-                .socialId(UUID.randomUUID().toString())
-                .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
-                .socialAccount(SocialAccount.KAKAO)
-                .build());
-
+        User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
 
-        String longContent = "a".repeat(101);
-
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.valueOf("FOOD"),
+                FeedCategory.FOOD,
                 8000L,
-                longContent, // @Size(max=100)
-                "feeds/uuid_test.jpg",
+                "a".repeat(101),
+                List.of("feeds/test.jpg"),
                 1080,
                 1350
         );
@@ -175,8 +187,7 @@ class FeedControllerTest {
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -192,11 +203,11 @@ class FeedControllerTest {
         String token = jwtTokenService.createAccessToken(user.getId());
 
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.valueOf("FOOD"),
+                FeedCategory.FOOD, // valueOf("FOOD") 대신 Enum 직접 사용 권장
                 8000L,
                 "두쫀쿠 맛있어보이는데 살까 말까",
-                "feeds/uuid_test.jpg",
-                0,      // @Positive
+                List.of("feeds/uuid_test.jpg"), // String -> List<String>으로 수정
+                0,      // @Positive 검증 대상
                 1350
         );
 
@@ -212,7 +223,7 @@ class FeedControllerTest {
     // ===== 피드 리스트 조회 =====
 
     @Test
-    @DisplayName("피드 리스트 조회 성공 - 200 OK, viewUrl에 CloudFront 전체 URL 반환")
+    @DisplayName("피드 리스트 조회 성공 - 200 OK, imageUrls에 CloudFront 전체 URL 리스트 반환")
     void getFeedList_success() throws Exception {
         // given
         User user = createUser();
@@ -227,8 +238,8 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content[0].feedId").value(feed.getId()))
                 .andExpect(jsonPath("$.data.content[0].author.userId").value(user.getId()))
-                .andExpect(jsonPath("$.data.content[0].s3ObjectKey").value(org.hamcrest.Matchers.startsWith("feeds/")))
-                .andExpect(jsonPath("$.data.content[0].viewUrl").value(org.hamcrest.Matchers.startsWith("https://")));
+                .andExpect(jsonPath("$.data.content[0].imageUrls").isArray())
+                .andExpect(jsonPath("$.data.content[0].imageUrls[0]").value(org.hamcrest.Matchers.startsWith("https://")));
     }
 
     @Test
@@ -243,6 +254,25 @@ class FeedControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("200"))
                 .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("피드 리스트 조회 성공 - 여러 장의 이미지가 있을 경우")
+    void getFeedList_with_multiple_images() throws Exception {
+        // given
+        User user = createUser();
+        Feed feed = feedRepository.save(Feed.builder()
+                .user(user).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS).imageWidth(100).imageHeight(100).build());
+
+        // 이미지 2개 저장
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].imageUrls").isArray())
+                .andExpect(jsonPath("$.data.content[0].imageUrls.length()").value(2));
     }
 
     // ===== 피드 삭제 =====
@@ -506,8 +536,8 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.feedId").value(feed.getId()))
                 .andExpect(jsonPath("$.data.content").value("테스트 피드"))
                 .andExpect(jsonPath("$.data.author.userId").value(user.getId()))
-                .andExpect(jsonPath("$.data.s3ObjectKey").value(org.hamcrest.Matchers.startsWith("feeds/")))
-                .andExpect(jsonPath("$.data.viewUrl").value(org.hamcrest.Matchers.startsWith("https://")));
+                .andExpect(jsonPath("$.data.imageUrls").isArray())
+                .andExpect(jsonPath("$.data.imageUrls[0]").value(org.hamcrest.Matchers.startsWith("https://")));
     }
 
     @Test

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -4,7 +4,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,12 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequest;
+import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateRequestV2;
 import com.nexters.sseotdabwa.domain.auth.service.JwtTokenService;
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.entity.FeedImage;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
-import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
-import com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedImageRepository;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedRepository;
 import com.nexters.sseotdabwa.domain.users.entity.User;
@@ -66,11 +64,11 @@ class FeedControllerTest {
     @Autowired
     private UserBlockRepository userBlockRepository;
 
-    // ===== 피드 등록 =====
+    // ===== 피드 등록 V1 =====
 
     @Test
-    @DisplayName("피드 등록 성공 - 이미지 1개 등록")
-    void createFeed_success_single_image() throws Exception {
+    @DisplayName("[V1] 피드 등록 성공 - 단일 이미지")
+    void createFeed_v1_success() throws Exception {
         // given
         User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
@@ -79,7 +77,7 @@ class FeedControllerTest {
                 FeedCategory.FOOD,
                 8000L,
                 "두쫀쿠 맛있어보이는데 살까 말까",
-                List.of("feeds/image1.jpg"), // 리스트로 변경
+                "feeds/image1.jpg",
                 1080,
                 1350
         );
@@ -94,8 +92,8 @@ class FeedControllerTest {
     }
 
     @Test
-    @DisplayName("피드 등록 성공 - 이미지 3개(최대) 등록")
-    void createFeed_success_max_images() throws Exception {
+    @DisplayName("[V1] 피드 등록 실패 - s3ObjectKey 빈 문자열이면 400")
+    void createFeed_v1_invalid_blankKey_returns400() throws Exception {
         // given
         User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
@@ -103,32 +101,8 @@ class FeedControllerTest {
         FeedCreateRequest request = new FeedCreateRequest(
                 FeedCategory.FOOD,
                 8000L,
-                "이미지 3개 테스트",
-                List.of("feeds/1.jpg", "feeds/2.jpg", "feeds/3.jpg"),
-                1080,
-                1350
-        );
-
-        // when & then
-        mockMvc.perform(post("/api/v1/feeds")
-                        .header("Authorization", "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated());
-    }
-
-    @Test
-    @DisplayName("피드 등록 실패 - 이미지 0개면 400 (NotEmpty)")
-    void createFeed_invalid_image_empty_returns400() throws Exception {
-        // given
-        User user = createUser();
-        String token = jwtTokenService.createAccessToken(user.getId());
-
-        FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.FOOD,
-                8000L,
-                "이미지 없음",
-                Collections.emptyList(), // @NotEmpty 검증 대상
+                "내용",
+                "",  // @NotBlank 검증 대상
                 1080,
                 1350
         );
@@ -143,32 +117,8 @@ class FeedControllerTest {
     }
 
     @Test
-    @DisplayName("피드 등록 실패 - 이미지 4개 이상이면 400 (Size)")
-    void createFeed_invalid_image_too_many_returns400() throws Exception {
-        // given
-        User user = createUser();
-        String token = jwtTokenService.createAccessToken(user.getId());
-
-        FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.FOOD,
-                8000L,
-                "이미지 4개",
-                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg"), // @Size(max=3)
-                1080,
-                1350
-        );
-
-        // when & then
-        mockMvc.perform(post("/api/v1/feeds")
-                        .header("Authorization", "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("피드 등록 실패 - content 100자 초과면 400")
-    void createFeed_invalid_content_tooLong_returns400() throws Exception {
+    @DisplayName("[V1] 피드 등록 실패 - content 100자 초과면 400")
+    void createFeed_v1_invalid_contentTooLong_returns400() throws Exception {
         // given
         User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
@@ -177,7 +127,7 @@ class FeedControllerTest {
                 FeedCategory.FOOD,
                 8000L,
                 "a".repeat(101),
-                List.of("feeds/test.jpg"),
+                "feeds/test.jpg",
                 1080,
                 1350
         );
@@ -191,8 +141,8 @@ class FeedControllerTest {
     }
 
     @Test
-    @DisplayName("피드 등록 실패 - imageWidth 0이면 400")
-    void createFeed_invalid_imageWidth_returns400() throws Exception {
+    @DisplayName("[V1] 피드 등록 실패 - imageWidth 0이면 400")
+    void createFeed_v1_invalid_imageWidth_returns400() throws Exception {
         // given
         User user = userRepository.save(User.builder()
                 .socialId(UUID.randomUUID().toString())
@@ -203,11 +153,11 @@ class FeedControllerTest {
         String token = jwtTokenService.createAccessToken(user.getId());
 
         FeedCreateRequest request = new FeedCreateRequest(
-                FeedCategory.FOOD, // valueOf("FOOD") 대신 Enum 직접 사용 권장
+                FeedCategory.FOOD,
                 8000L,
                 "두쫀쿠 맛있어보이는데 살까 말까",
-                List.of("feeds/uuid_test.jpg"), // String -> List<String>으로 수정
-                0,      // @Positive 검증 대상
+                "feeds/uuid_test.jpg",
+                0,  // @Positive 검증 대상
                 1350
         );
 
@@ -220,11 +170,115 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
     }
 
-    // ===== 피드 리스트 조회 =====
+    // ===== 피드 등록 V2 =====
 
     @Test
-    @DisplayName("피드 리스트 조회 성공 - 200 OK, imageUrls에 CloudFront 전체 URL 리스트 반환")
-    void getFeedList_success() throws Exception {
+    @DisplayName("[V2] 피드 등록 성공 - 이미지 1개")
+    void createFeed_v2_success_singleImage() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "두쫀쿠 맛있어보이는데 살까 말까",
+                List.of("feeds/image1.jpg"),
+                1080,
+                1350
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.feedId").exists());
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 등록 성공 - 이미지 3개(최대), DB에 FeedImage 3건 저장")
+    void createFeed_v2_success_maxImages() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "이미지 3개 테스트",
+                List.of("feeds/1.jpg", "feeds/2.jpg", "feeds/3.jpg"),
+                1080,
+                1350
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.feedId").exists());
+
+        // DB에 이미지 3건 저장 확인
+        org.assertj.core.api.Assertions.assertThat(feedImageRepository.count()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 등록 실패 - 이미지 0개면 400 (NotEmpty)")
+    void createFeed_v2_invalid_imageEmpty_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "이미지 없음",
+                List.of(),  // @NotEmpty 검증 대상
+                1080,
+                1350
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 등록 실패 - 이미지 4개 이상이면 400 (Size)")
+    void createFeed_v2_invalid_imageTooMany_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "이미지 4개",
+                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg"),  // @Size(max=3)
+                1080,
+                1350
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ===== 피드 리스트 조회 V1 =====
+
+    @Test
+    @DisplayName("[V1] 피드 리스트 조회 성공 - viewUrl(단건) 반환")
+    void getFeedList_v1_success() throws Exception {
         // given
         User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
@@ -238,13 +292,31 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content[0].feedId").value(feed.getId()))
                 .andExpect(jsonPath("$.data.content[0].author.userId").value(user.getId()))
-                .andExpect(jsonPath("$.data.content[0].imageUrls").isArray())
-                .andExpect(jsonPath("$.data.content[0].imageUrls[0]").value(org.hamcrest.Matchers.startsWith("https://")));
+                .andExpect(jsonPath("$.data.content[0].viewUrl").value(org.hamcrest.Matchers.startsWith("https://")));
     }
 
     @Test
-    @DisplayName("피드 리스트 조회 성공 - 비로그인 유저도 접근 가능")
-    void getFeedList_noAuth_success() throws Exception {
+    @DisplayName("[V1] 피드 리스트 조회 - 이미지 여러 장이어도 첫 번째 이미지만 viewUrl로 반환")
+    void getFeedList_v1_multipleImages_returnsFirstOnly() throws Exception {
+        // given
+        User user = createUser();
+        Feed feed = feedRepository.save(Feed.builder()
+                .user(user).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS)
+                .imageWidth(100).imageHeight(100).build());
+
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").build());
+
+        // when & then - V1은 첫 번째 이미지만 viewUrl(단건) 반환
+        mockMvc.perform(get("/api/v1/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].viewUrl").exists())
+                .andExpect(jsonPath("$.data.content[0].s3ObjectKey").value("img1.jpg"));
+    }
+
+    @Test
+    @DisplayName("[V1] 피드 리스트 조회 성공 - 비로그인 유저도 접근 가능")
+    void getFeedList_v1_noAuth_success() throws Exception {
         // given
         User user = createUser();
         createFeedWithImage(user);
@@ -256,20 +328,51 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.content").isArray());
     }
 
+    // ===== 피드 리스트 조회 V2 =====
+
     @Test
-    @DisplayName("피드 리스트 조회 성공 - 여러 장의 이미지가 있을 경우")
-    void getFeedList_with_multiple_images() throws Exception {
+    @DisplayName("[V2] 피드 리스트 조회 성공 - 비로그인 유저도 접근 가능")
+    void getFeedList_v2_noAuth_success() throws Exception {
         // given
         User user = createUser();
-        Feed feed = feedRepository.save(Feed.builder()
-                .user(user).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS).imageWidth(100).imageHeight(100).build());
+        createFeedWithImage(user);
 
-        // 이미지 2개 저장
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 단건 조회 성공 - 비로그인 유저도 접근 가능")
+    void getFeedDetail_v2_noAuth_success() throws Exception {
+        // given
+        User user = createUser();
+        Feed feed = createFeedWithImage(user);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds/" + feed.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.feedId").value(feed.getId()))
+                .andExpect(jsonPath("$.data.hasVoted").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 성공 - imageUrls(다중) 반환")
+    void getFeedList_v2_success() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = feedRepository.save(Feed.builder()
+                .user(user).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS)
+                .imageWidth(100).imageHeight(100).build());
+
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").build());
 
         // when & then
-        mockMvc.perform(get("/api/v1/feeds"))
+        mockMvc.perform(get("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].imageUrls").isArray())
                 .andExpect(jsonPath("$.data.content[0].imageUrls.length()").value(2));
@@ -518,11 +621,11 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.nextCursor").exists());
     }
 
-    // ===== 피드 단건 조회 =====
+    // ===== 피드 단건 조회 V1 =====
 
     @Test
-    @DisplayName("피드 단건 조회 성공 - 로그인 유저 200 OK")
-    void getFeedDetail_success() throws Exception {
+    @DisplayName("[V1] 피드 단건 조회 성공 - viewUrl(단건) 반환")
+    void getFeedDetail_v1_success() throws Exception {
         // given
         User user = createUser();
         String token = jwtTokenService.createAccessToken(user.getId());
@@ -536,13 +639,12 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.feedId").value(feed.getId()))
                 .andExpect(jsonPath("$.data.content").value("테스트 피드"))
                 .andExpect(jsonPath("$.data.author.userId").value(user.getId()))
-                .andExpect(jsonPath("$.data.imageUrls").isArray())
-                .andExpect(jsonPath("$.data.imageUrls[0]").value(org.hamcrest.Matchers.startsWith("https://")));
+                .andExpect(jsonPath("$.data.viewUrl").value(org.hamcrest.Matchers.startsWith("https://")));
     }
 
     @Test
-    @DisplayName("피드 단건 조회 성공 - 비로그인 유저도 접근 가능, hasVoted/myVoteChoice null")
-    void getFeedDetail_noAuth_success() throws Exception {
+    @DisplayName("[V1] 피드 단건 조회 성공 - 비로그인 유저도 접근 가능, hasVoted/myVoteChoice null")
+    void getFeedDetail_v1_noAuth_success() throws Exception {
         // given
         User user = createUser();
         Feed feed = createFeedWithImage(user);
@@ -586,6 +688,30 @@ class FeedControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.hasVoted").value(true))
                 .andExpect(jsonPath("$.data.myVoteChoice").value("YES"));
+    }
+
+    // ===== 피드 단건 조회 V2 =====
+
+    @Test
+    @DisplayName("[V2] 피드 단건 조회 성공 - imageUrls(다중) 반환")
+    void getFeedDetail_v2_success() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = feedRepository.save(Feed.builder()
+                .user(user).content("다중이미지 피드").price(10000L).category(FeedCategory.FASHION)
+                .imageWidth(300).imageHeight(400).build());
+
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds/" + feed.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.feedId").value(feed.getId()))
+                .andExpect(jsonPath("$.data.imageUrls").isArray())
+                .andExpect(jsonPath("$.data.imageUrls.length()").value(2));
     }
 
     // ===== 피드 리스트 feedStatus 필터 =====

--- a/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
@@ -306,6 +306,35 @@ class UserControllerTest {
                 .build());
     }
 
+    // ===== 내가 작성한 피드 조회 V2 =====
+
+    @Test
+    @DisplayName("[V2] 내가 작성한 피드 조회 성공 - imageUrls(다중) 반환")
+    void getMyFeeds_v2_success_multipleImages() throws Exception {
+        // given
+        User user = createUser();
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = createFeed(user);
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("feeds/img1.jpg").build());
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("feeds/img2.jpg").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/users/me/feeds")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].feedId").value(feed.getId()))
+                .andExpect(jsonPath("$.data.content[0].imageUrls").isArray())
+                .andExpect(jsonPath("$.data.content[0].imageUrls.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("[V2] 내가 작성한 피드 조회 실패 - 비로그인 401")
+    void getMyFeeds_v2_unauthorized_returns401() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v2/users/me/feeds"))
+                .andExpect(status().isUnauthorized());
+    }
+
     @Test
     @DisplayName("FCM 토큰 등록/갱신 성공 - DB에 fcmToken 저장")
     void updateFcmToken_success_updatesDb() throws Exception {

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
@@ -66,7 +66,7 @@ class FeedImageServiceTest {
         feedImageService.saveAll(feed, keys);
 
         // then
-        List<FeedImage> savedImages = feedImageRepository.findByFeed(feed);
+        List<FeedImage> savedImages = feedImageRepository.findByFeedOrderByIdAsc(feed);
         assertThat(savedImages).hasSize(3);
         assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
                 .containsExactlyInAnyOrder("key1.jpg", "key2.jpg", "key3.jpg");
@@ -83,7 +83,7 @@ class FeedImageServiceTest {
         feedImageService.saveAll(feed, List.of("  feeds/trim1.jpg  ", "  feeds/trim2.jpg  "));
 
         // then
-        List<FeedImage> savedImages = feedImageRepository.findByFeed(feed);
+        List<FeedImage> savedImages = feedImageRepository.findByFeedOrderByIdAsc(feed);
         assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
                 .containsExactlyInAnyOrder("feeds/trim1.jpg", "feeds/trim2.jpg");
     }

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
@@ -69,7 +69,7 @@ class FeedImageServiceTest {
         List<FeedImage> savedImages = feedImageRepository.findByFeedOrderByIdAsc(feed);
         assertThat(savedImages).hasSize(3);
         assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
-                .containsExactlyInAnyOrder("key1.jpg", "key2.jpg", "key3.jpg");
+                .containsExactly("key1.jpg", "key2.jpg", "key3.jpg");
     }
 
     @Test
@@ -85,7 +85,7 @@ class FeedImageServiceTest {
         // then
         List<FeedImage> savedImages = feedImageRepository.findByFeedOrderByIdAsc(feed);
         assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
-                .containsExactlyInAnyOrder("feeds/trim1.jpg", "feeds/trim2.jpg");
+                .containsExactly("feeds/trim1.jpg", "feeds/trim2.jpg");
     }
 
     @Test

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedImageServiceTest.java
@@ -43,8 +43,8 @@ class FeedImageServiceTest {
         User user = createUser();
         Feed feed = createFeed(user);
 
-        // when
-        feedImageService.save(feed, "feeds/abc.jpg");
+        // when -
+        feedImageService.saveAll(feed, List.of("feeds/abc.jpg"));
 
         // then
         assertThat(feedImageRepository.count()).isEqualTo(1);
@@ -55,18 +55,37 @@ class FeedImageServiceTest {
     }
 
     @Test
-    @DisplayName("피드 이미지 저장 성공 - s3ObjectKey trim 적용")
-    void save_trimApplied() {
+    @DisplayName("피드 이미지 다중 저장 성공 - 이미지 3건 저장")
+    void saveAll_multiple_success() {
+        // given
+        User user = createUser();
+        Feed feed = createFeed(user);
+        List<String> keys = List.of("key1.jpg", "key2.jpg", "key3.jpg");
+
+        // when
+        feedImageService.saveAll(feed, keys);
+
+        // then
+        List<FeedImage> savedImages = feedImageRepository.findByFeed(feed);
+        assertThat(savedImages).hasSize(3);
+        assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
+                .containsExactlyInAnyOrder("key1.jpg", "key2.jpg", "key3.jpg");
+    }
+
+    @Test
+    @DisplayName("피드 이미지 저장 성공 - 모든 s3ObjectKey에 trim 적용")
+    void saveAll_trimApplied() {
         // given
         User user = createUser();
         Feed feed = createFeed(user);
 
         // when
-        feedImageService.save(feed, "  feeds/trim.jpg  ");
+        feedImageService.saveAll(feed, List.of("  feeds/trim1.jpg  ", "  feeds/trim2.jpg  "));
 
         // then
-        FeedImage saved = feedImageRepository.findAll().get(0);
-        assertThat(saved.getS3ObjectKey()).isEqualTo("feeds/trim.jpg");
+        List<FeedImage> savedImages = feedImageRepository.findByFeed(feed);
+        assertThat(savedImages).extracting(FeedImage::getS3ObjectKey)
+                .containsExactlyInAnyOrder("feeds/trim1.jpg", "feeds/trim2.jpg");
     }
 
     @Test

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.nexters.sseotdabwa.domain.feeds.service.command.FeedCreateCommand;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -655,14 +657,51 @@ class FeedServiceTest {
         });
     }
 
+    @Test
+    @DisplayName("다중 이미지를 포함한 피드 생성 성공")
+    void createFeed_with_multiple_images_success() {
+        // given
+        User user = createUser();
+        List<String> images = List.of("img1.jpg", "img2.jpg", "img3.jpg");
+        FeedCreateCommand command = new FeedCreateCommand(
+                user, "내용", 5000L, FeedCategory.ELECTRONICS, 100, 100, images
+        );
+
+        // when
+        Feed savedFeed = feedService.createFeed(command);
+
+        // then
+        assertThat(savedFeed.getId()).isNotNull();
+        assertThat(savedFeed.getContent()).isEqualTo("내용");
+        // 이미지 엔티티 저장은 FeedFacade가 담당하므로 여기서는 Feed 엔티티 필드만 확인
+    }
+
+    @Test
+    @DisplayName("이미지 3개 초과 생성 시 실패")
+    void createFeed_too_many_images_fail() {
+        // given
+        User user = createUser();
+        List<String> images = List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg");
+        FeedCreateCommand command = new FeedCreateCommand(
+                user, "내용", 5000L, FeedCategory.FASHION, 100, 100, images
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(command))
+                .isInstanceOf(GlobalException.class);
+    }
+
     private Feed createFeed(User user) {
-        return feedRepository.save(Feed.builder()
-                .user(user)
-                .content("테스트 피드")
-                .price(10000L)
-                .category(FeedCategory.FASHION)
-                .imageWidth(300)
-                .imageHeight(400)
-                .build());
+        // FeedService의 createFeed를 직접 호출하여 도메인 로직(검증 등)을 함께 테스트
+        FeedCreateCommand command = new FeedCreateCommand(
+                user,
+                "테스트 피드 내용",
+                10000L,
+                FeedCategory.FASHION,
+                300,
+                400,
+                List.of("feeds/test-image.jpg")
+        );
+        return feedService.createFeed(command);
     }
 }

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
@@ -112,6 +112,36 @@ class FeedServiceUnitTest {
     }
 
     @Test
+    @DisplayName("피드 생성 실패 - s3ObjectKeys 리스트 내부 원소에 null이나 공백이 포함되면 FEED_IMAGE_REQUIRED")
+    void createFeed_s3KeyListContainsInvalidElement_throws() {
+        // given
+        User user = User.builder().socialId("x").nickname("n").build();
+
+        // 1. null 원소가 포함된 경우
+        FeedCreateCommand commandWithNull = new FeedCreateCommand(
+                user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
+                Collections.singletonList(null)
+        );
+
+        // 2. 공백 원소가 포함된 경우
+        FeedCreateCommand commandWithBlank = new FeedCreateCommand(
+                user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
+                List.of("  ")
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(commandWithNull))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_IMAGE_REQUIRED);
+
+        assertThatThrownBy(() -> feedService.createFeed(commandWithBlank))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_IMAGE_REQUIRED);
+
+        verifyNoInteractions(feedRepository);
+    }
+
+    @Test
     @DisplayName("피드 생성 실패 - 이미지 3개 초과 시 FEED_IMAGE_LIMIT_EXCEEDED")
     void createFeed_imageLimitExceeded_throws() {
         // given

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,7 +39,7 @@ class FeedServiceUnitTest {
     private FeedService feedService;
 
     @Test
-    @DisplayName("피드 생성 성공 - Feed/FeedImage 저장 후 feedId 반환")
+    @DisplayName("피드 생성 성공 - Feed 저장 후 반환")
     void createFeed_success() {
         // given
         User user = User.builder()
@@ -53,10 +54,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 1080,
                 720,
-                "  feeds/abc.jpg  "
+                List.of("feeds/abc.jpg") // List로 변경
         );
 
-        // FeedRepository.save()가 id=1L인 Feed를 반환하도록 스텁
         Feed savedFeed = Feed.builder()
                 .user(user)
                 .content("내용입니다")
@@ -77,19 +77,62 @@ class FeedServiceUnitTest {
         // then
         assertThat(result.getId()).isEqualTo(1L);
 
-        // Feed 저장 내용 검증
         ArgumentCaptor<Feed> feedCaptor = ArgumentCaptor.forClass(Feed.class);
         verify(feedRepository, times(1)).save(feedCaptor.capture());
 
         Feed capturedFeed = feedCaptor.getValue();
-        assertThat(capturedFeed.getUser()).isEqualTo(user);
-        assertThat(capturedFeed.getContent()).isEqualTo("내용입니다"); // trim 반영
+        assertThat(capturedFeed.getContent()).isEqualTo("내용입니다");
         assertThat(capturedFeed.getPrice()).isEqualTo(10000L);
-        assertThat(capturedFeed.getCategory()).isEqualTo(FeedCategory.FOOD);
-        assertThat(capturedFeed.getImageWidth()).isEqualTo(1080);
-        assertThat(capturedFeed.getImageHeight()).isEqualTo(720);
 
         verifyNoMoreInteractions(feedRepository);
+    }
+
+    @Test
+    @DisplayName("피드 생성 실패 - 이미지가 없으면(Empty List) FEED_IMAGE_REQUIRED")
+    void createFeed_imageEmpty_throws() {
+        // given
+        User user = User.builder().socialId("x").nickname("n").build();
+
+        FeedCreateCommand command = new FeedCreateCommand(
+                user,
+                "내용",
+                10000L,
+                FeedCategory.FOOD,
+                100,
+                100,
+                Collections.emptyList()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(command))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_IMAGE_REQUIRED);
+
+        verifyNoInteractions(feedRepository);
+    }
+
+    @Test
+    @DisplayName("피드 생성 실패 - 이미지 3개 초과 시 FEED_IMAGE_LIMIT_EXCEEDED")
+    void createFeed_imageLimitExceeded_throws() {
+        // given
+        User user = User.builder().socialId("x").nickname("n").build();
+
+        FeedCreateCommand command = new FeedCreateCommand(
+                user,
+                "내용",
+                10000L,
+                FeedCategory.FOOD,
+                100,
+                100,
+                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg") // 4개 전달
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(command))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_IMAGE_LIMIT_EXCEEDED);
+
+        verifyNoInteractions(feedRepository);
     }
 
     @Test
@@ -106,7 +149,7 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                "feeds/abc.jpg"
+                List.of("feeds/1.jpg", "feeds/2.jpg")
         );
 
         // when & then
@@ -142,30 +185,6 @@ class FeedServiceUnitTest {
     }
 
     @Test
-    @DisplayName("피드 생성 실패 - s3ObjectKey가 blank이면 FEED_IMAGE_REQUIRED")
-    void createFeed_s3KeyBlank_throws() {
-        // given
-        User user = User.builder().socialId("x").nickname("n").build();
-
-        FeedCreateCommand command = new FeedCreateCommand(
-                user,
-                "내용",
-                10000L,
-                FeedCategory.FOOD,
-                100,
-                100,
-                "   "
-        );
-
-        // when & then
-        assertThatThrownBy(() -> feedService.createFeed(command))
-                .isInstanceOf(GlobalException.class)
-                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_IMAGE_REQUIRED);
-
-        verifyNoInteractions(feedRepository);
-    }
-
-    @Test
     @DisplayName("피드 생성 성공 - content가 null이면 빈 문자열로 저장(정책상 허용되는 현재 구현)")
     void createFeed_nullContent_savedAsEmptyString() {
         // given
@@ -178,7 +197,7 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                "feeds/abc.jpg"
+                List.of("feeds/1.jpg", "feeds/2.jpg")
         );
 
         Feed savedFeed = spy(Feed.builder()


### PR DESCRIPTION
### 🚀 Issue Number
#103 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#103-feed-multi-image` → `develop`

### 🔎 작업 내용
- 이미지 다중 등록 기능 구현
  - 하나의 피드에 여러 장의 이미지 등록
  - 피드와 이미지를 Feed ↔ FeedImage (1:N) 관계로 저장 구조 확장
- DB 스키마 변경
  - feed_images 테이블의 feed_id Unique 제약 조건 및 인덱스 삭제
  - 중복 허용을 위한 일반 Foreign Key 및 인덱스 재설정
- API 유효성 검사 로직 추가
  - 이미지 최소 1장, 최대 3장 업로드 제한 정책 적용
  - 3장 초과 시 400 Bad Request 반환 및 커스텀 에러 코드(FEED_IMAGE_LIMIT_EXCEEDED) 응답
- 기존 단일 이미지 로직 확장
  - FeedCreateRequest DTO의 이미지 필드를 List<String>으로 수정
  - FeedImageService.saveAll 도입을 통한 일괄 저장 로직 구현
- 테스트 코드 전반 수정 및 보강
  - 다중 이미지 업로드 관련 단위 테스트 및 컨트롤러 통합 테스트 추가
  - 이미지 개수 제한 및 Trim 적용 여부 검증 테스트 작성

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `FeedControllerTest.java` | ✅ Pass |
| `FeedServiceTest.java` | ✅ Pass |
| `FeedServiceUnitTest.java` | ✅ Pass |
| `FeedImageServiceTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드에 최대 3장의 이미지 업로드 기능 추가
  * V2 API 엔드포인트 출시: 여러 이미지가 포함된 피드 생성 및 조회 지원
  * 내 피드 조회 V2 엔드포인트 추가로 모든 이미지 URL 반환

* **개선 사항**
  * 테스트 커버리지 80.1%에서 82.0%로 향상
  * 이미지 업로드 제한 초과 시 명확한 오류 메시지 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->