### PR TITLE
[FEATURE] #107 피드에 link/title 필드 추가 및 피드 조회 시 본인 피드 자동 제외

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.2%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.3%25-brightgreen)
 # Sseotdabwa-BE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.0%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.2%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequestV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedCreateRequestV2.java
@@ -1,5 +1,6 @@
 package com.nexters.sseotdabwa.api.feeds.dto;
 
+import com.nexters.sseotdabwa.common.validation.ValidUrl;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import jakarta.validation.constraints.*;
 
@@ -27,6 +28,12 @@ public record FeedCreateRequestV2(
 
         @NotNull(message = "이미지 높이는 필수입니다.")
         @Positive(message = "이미지 높이는 1 이상이어야 합니다.")
-        Integer imageHeight
+        Integer imageHeight,
+
+        @ValidUrl
+        String link,
+
+        @Size(max = 40, message = "제목은 40자 이하로 입력해주세요.")
+        String title
 ) {
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponseV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/dto/FeedResponseV2.java
@@ -25,7 +25,9 @@ public record FeedResponseV2(
         FeedAuthorResponse author,
         LocalDateTime createdAt,
         Boolean hasVoted,
-        VoteChoice myVoteChoice
+        VoteChoice myVoteChoice,
+        String link,
+        String title
 ) {
 
     public record FeedAuthorResponse(
@@ -55,7 +57,9 @@ public record FeedResponseV2(
                 ),
                 feed.getCreatedAt(),
                 null,
-                null
+                null,
+                feed.getLink(),
+                feed.getTitle()
         );
     }
 
@@ -80,7 +84,9 @@ public record FeedResponseV2(
                 ),
                 feed.getCreatedAt(),
                 hasVoted,
-                myVoteChoice
+                myVoteChoice,
+                feed.getLink(),
+                feed.getTitle()
         );
     }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
@@ -71,7 +71,9 @@ public class FeedFacade {
                 request.category(),
                 request.imageWidth(),
                 request.imageHeight(),
-                List.of(request.s3ObjectKey())
+                List.of(request.s3ObjectKey()),
+                null,
+                null
         );
 
         Feed savedFeed = feedService.createFeed(command);
@@ -171,7 +173,9 @@ public class FeedFacade {
                 request.category(),
                 request.imageWidth(),
                 request.imageHeight(),
-                request.s3ObjectKeys()
+                request.s3ObjectKeys(),
+                request.link(),
+                request.title()
         );
 
         Feed savedFeed = feedService.createFeed(command);
@@ -207,9 +211,13 @@ public class FeedFacade {
     public CursorPageResponse<FeedResponseV2> getFeedListV2(User user, Long cursor, Integer size, FeedStatus feedStatus) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
-        List<Long> excludedUserIds = (user != null)
-                ? userBlockService.findBlockedUserIds(user.getId())
-                : Collections.emptyList();
+        List<Long> excludedUserIds;
+        if (user != null) {
+            excludedUserIds = new java.util.ArrayList<>(userBlockService.findBlockedUserIds(user.getId()));
+            excludedUserIds.add(user.getId());
+        } else {
+            excludedUserIds = Collections.emptyList();
+        }
 
         List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, excludedUserIds);
 

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/dto/NotificationResponse.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/dto/NotificationResponse.java
@@ -16,14 +16,16 @@ public record NotificationResponse(
 
         Integer resultPercent,
         String resultLabel,
-        String viewUrl
+        String viewUrl,
+        String feedTitle
 ) {
     public static NotificationResponse of(
             Notification n,
             LocalDateTime voteClosedAt,
             Integer resultPercent,
             String resultLabel,
-            String viewUrl
+            String viewUrl,
+            String feedTitle
     ) {
         return new NotificationResponse(
                 n.getId(),
@@ -35,7 +37,8 @@ public record NotificationResponse(
                 voteClosedAt,
                 resultPercent,
                 resultLabel,
-                viewUrl
+                viewUrl,
+                feedTitle
         );
     }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
@@ -106,7 +106,8 @@ public class NotificationFacade {
                             voteClosedAt,
                             result.resultPercent(),
                             result.resultLabel(),
-                            viewUrl
+                            viewUrl,
+                            feed.getTitle()
                     );
                 })
                 .toList();

--- a/src/main/java/com/nexters/sseotdabwa/common/validation/UrlValidator.java
+++ b/src/main/java/com/nexters/sseotdabwa/common/validation/UrlValidator.java
@@ -8,14 +8,17 @@ import java.util.regex.Pattern;
 /**
  * URL 유효성 검증기
  * - http/https 스킴만 허용
+ * - 호스트에 점(.)이 포함된 유효한 도메인 필수 (https://foo 같은 호스트 없는 URL 거부)
  * - 도메인에 한글 문자 불허
  * - 공백 불허
  */
 public class UrlValidator implements ConstraintValidator<ValidUrl, String> {
 
     private static final Pattern URL_PATTERN = Pattern.compile(
-            "^https?://" +               // http:// 또는 https://
-            "[a-zA-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]+" + // ASCII 문자만 허용 (공백, 한글 제외)
+            "^https?://" +                                          // http:// 또는 https://
+            "[a-zA-Z0-9][a-zA-Z0-9\\-]*(\\.[a-zA-Z0-9\\-]+)+" +  // 점이 포함된 호스트 필수 (e.g. example.com)
+            "(:\\d{1,5})?" +                                        // 포트 (선택)
+            "([/?#][^\\s]*)?" +                                     // 경로/쿼리/프래그먼트 (선택)
             "$"
     );
 

--- a/src/main/java/com/nexters/sseotdabwa/common/validation/UrlValidator.java
+++ b/src/main/java/com/nexters/sseotdabwa/common/validation/UrlValidator.java
@@ -1,0 +1,32 @@
+package com.nexters.sseotdabwa.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+/**
+ * URL 유효성 검증기
+ * - http/https 스킴만 허용
+ * - 도메인에 한글 문자 불허
+ * - 공백 불허
+ */
+public class UrlValidator implements ConstraintValidator<ValidUrl, String> {
+
+    private static final Pattern URL_PATTERN = Pattern.compile(
+            "^https?://" +               // http:// 또는 https://
+            "[a-zA-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]+" + // ASCII 문자만 허용 (공백, 한글 제외)
+            "$"
+    );
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true; // null/blank는 통과 (필수 여부는 @NotBlank로 제어)
+        }
+        if (value.contains(" ")) {
+            return false;
+        }
+        return URL_PATTERN.matcher(value).matches();
+    }
+}

--- a/src/main/java/com/nexters/sseotdabwa/common/validation/ValidUrl.java
+++ b/src/main/java/com/nexters/sseotdabwa/common/validation/ValidUrl.java
@@ -1,0 +1,19 @@
+package com.nexters.sseotdabwa.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UrlValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidUrl {
+
+    String message() default "유효하지 않은 URL입니다. http 또는 https로 시작하는 URL을 입력해주세요.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/entity/Feed.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/entity/Feed.java
@@ -62,14 +62,22 @@ public class Feed extends BaseEntity {
     @Column(nullable = false)
     private Integer imageHeight;
 
+    @Column(length = 500)
+    private String link;
+
+    @Column(length = 40)
+    private String title;
+
     @Builder
-    public Feed(User user, String content, Long price, FeedCategory category, Integer imageWidth, Integer imageHeight) {
+    public Feed(User user, String content, Long price, FeedCategory category, Integer imageWidth, Integer imageHeight, String link, String title) {
         this.user = user;
         this.content = content;
         this.price = price;
         this.category = category;
         this.imageWidth = imageWidth;
         this.imageHeight = imageHeight;
+        this.link = link;
+        this.title = title;
         this.reportStatus = ReportStatus.NONE;
         this.feedStatus = FeedStatus.OPEN;
         this.yesCount = 0L;

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
@@ -20,7 +20,8 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "FEED_004", "본인의 피드만 삭제할 수 있습니다."),
     FEED_ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "FEED_005", "이미 신고된 피드입니다."),
     FEED_SELF_REPORT(HttpStatus.BAD_REQUEST, "FEED_006", "본인의 피드는 신고할 수 없습니다."),
-    FEED_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "FEED_007", "이미지는 최대 3장까지 업로드할 수 있습니다." );
+    FEED_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "FEED_007", "이미지는 최대 3장까지 업로드할 수 있습니다."),
+    FEED_INVALID_LINK(HttpStatus.BAD_REQUEST, "FEED_008", "유효하지 않은 URL입니다. http 또는 https로 시작하는 URL을 입력해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/exception/FeedErrorCode.java
@@ -21,7 +21,8 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "FEED_005", "이미 신고된 피드입니다."),
     FEED_SELF_REPORT(HttpStatus.BAD_REQUEST, "FEED_006", "본인의 피드는 신고할 수 없습니다."),
     FEED_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "FEED_007", "이미지는 최대 3장까지 업로드할 수 있습니다."),
-    FEED_INVALID_LINK(HttpStatus.BAD_REQUEST, "FEED_008", "유효하지 않은 URL입니다. http 또는 https로 시작하는 URL을 입력해주세요.");
+    FEED_INVALID_LINK(HttpStatus.BAD_REQUEST, "FEED_008", "유효하지 않은 URL입니다. http 또는 https로 시작하는 URL을 입력해주세요."),
+    FEED_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "FEED_009", "제목은 40자 이하로 입력해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -51,6 +51,8 @@ public class FeedService {
                 .category(command.category())
                 .imageWidth(command.imageWidth())
                 .imageHeight(command.imageHeight())
+                .link(command.link())
+                .title(command.title())
                 .build();
 
         return feedRepository.save(feed);

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -9,6 +9,7 @@ import com.nexters.sseotdabwa.domain.feeds.exception.FeedErrorCode;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus;
 import com.nexters.sseotdabwa.common.exception.GlobalException;
+import com.nexters.sseotdabwa.common.validation.UrlValidator;
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedRepository;
 import com.nexters.sseotdabwa.domain.feeds.service.command.FeedCreateCommand;
@@ -33,6 +34,10 @@ import java.util.List;
 public class FeedService {
 
     private static final int MAX_CONTENT_LENGTH = 100;
+    private static final int MAX_TITLE_LENGTH = 40;
+    private static final int MAX_LINK_LENGTH = 500;
+
+    private static final UrlValidator URL_VALIDATOR = new UrlValidator();
 
     private final FeedRepository feedRepository;
 
@@ -83,6 +88,20 @@ public class FeedService {
         // 리스트 내 단 하나라도 유효하지 않은 키가 있다면 예외를 던집니다.
         if (command.s3ObjectKeys().stream().anyMatch(key -> key == null || key.isBlank())) {
             throw new GlobalException(FeedErrorCode.FEED_IMAGE_REQUIRED);
+        }
+
+        // 5. link 검증 (값이 있는 경우에만)
+        String link = command.link();
+        if (link != null && !link.isBlank()) {
+            if (link.length() > MAX_LINK_LENGTH || !URL_VALIDATOR.isValid(link, null)) {
+                throw new GlobalException(FeedErrorCode.FEED_INVALID_LINK);
+            }
+        }
+
+        // 6. title 길이 검증 (값이 있는 경우에만)
+        String title = command.title();
+        if (title != null && title.length() > MAX_TITLE_LENGTH) {
+            throw new GlobalException(FeedErrorCode.FEED_TITLE_TOO_LONG);
         }
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/command/FeedCreateCommand.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/command/FeedCreateCommand.java
@@ -12,6 +12,8 @@ public record FeedCreateCommand(
         FeedCategory category,
         Integer imageWidth,
         Integer imageHeight,
-        List<String> s3ObjectKeys
+        List<String> s3ObjectKeys,
+        String link,
+        String title
 ) {
 }

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -185,7 +185,9 @@ class FeedControllerTest {
                 "두쫀쿠 맛있어보이는데 살까 말까",
                 List.of("feeds/image1.jpg"),
                 1080,
-                1350
+                1350,
+                null,
+                null
         );
 
         // when & then
@@ -210,7 +212,9 @@ class FeedControllerTest {
                 "이미지 3개 테스트",
                 List.of("feeds/1.jpg", "feeds/2.jpg", "feeds/3.jpg"),
                 1080,
-                1350
+                1350,
+                null,
+                null
         );
 
         // when & then
@@ -238,7 +242,9 @@ class FeedControllerTest {
                 "이미지 없음",
                 List.of(),  // @NotEmpty 검증 대상
                 1080,
-                1350
+                1350,
+                null,
+                null
         );
 
         // when & then
@@ -263,7 +269,9 @@ class FeedControllerTest {
                 "이미지 4개",
                 List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg"),  // @Size(max=3)
                 1080,
-                1350
+                1350,
+                null,
+                null
         );
 
         // when & then
@@ -361,16 +369,17 @@ class FeedControllerTest {
     @DisplayName("[V2] 피드 리스트 조회 성공 - imageUrls(다중) 반환")
     void getFeedList_v2_success() throws Exception {
         // given
-        User user = createUser();
-        String token = jwtTokenService.createAccessToken(user.getId());
+        User me = createUser();
+        User other = createUser();
+        String token = jwtTokenService.createAccessToken(me.getId());
         Feed feed = feedRepository.save(Feed.builder()
-                .user(user).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS)
+                .user(other).content("다중이미지").price(1000L).category(FeedCategory.ELECTRONICS)
                 .imageWidth(100).imageHeight(100).build());
 
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").build());
 
-        // when & then
+        // when & then - 로그인 시 본인 피드 제외, 타인 피드는 조회됨
         mockMvc.perform(get("/api/v2/feeds")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -835,6 +844,148 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.hasNext").value(false))
                 .andExpect(jsonPath("$.data.content[*].feedId",
                         org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(blockedFeed.getId().intValue()))));
+    }
+
+    // ===== 피드 등록 V2 link/title =====
+
+    @Test
+    @DisplayName("[V2] 피드 등록 성공 - 유효한 link와 title 포함")
+    void createFeed_v2_withLinkAndTitle_success() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "링크 포함 피드",
+                List.of("feeds/image1.jpg"),
+                1080,
+                1350,
+                "https://www.example.com/product/123",
+                "이 신발 살까 말까"
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.feedId").exists());
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 등록 실패 - http/https 아닌 link면 400")
+    void createFeed_v2_invalidLink_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "잘못된 링크",
+                List.of("feeds/image1.jpg"),
+                1080,
+                1350,
+                "ftp://invalid.com",
+                null
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 등록 실패 - title 40자 초과면 400")
+    void createFeed_v2_titleTooLong_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "내용",
+                List.of("feeds/image1.jpg"),
+                1080,
+                1350,
+                null,
+                "a".repeat(41)  // @Size(max=40)
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 단건 조회 - link와 title 반환 확인")
+    void getFeedDetail_v2_returnsLinkAndTitle() throws Exception {
+        // given
+        User user = createUser();
+        Feed feed = feedRepository.save(Feed.builder()
+                .user(user).content("링크 피드").price(5000L).category(FeedCategory.FOOD)
+                .imageWidth(100).imageHeight(100)
+                .link("https://www.example.com")
+                .title("살까 말까")
+                .build());
+        feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds/" + feed.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.link").value("https://www.example.com"))
+                .andExpect(jsonPath("$.data.title").value("살까 말까"));
+    }
+
+    // ===== 피드 리스트 V2 본인 피드 제외 =====
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - 로그인 시 본인 피드 자동 제외")
+    void getFeedList_v2_loggedIn_excludesMyFeeds() throws Exception {
+        // given
+        User me = createUser();
+        User other = createUser();
+        String myToken = jwtTokenService.createAccessToken(me.getId());
+
+        Feed myFeed = createFeedWithImage(me);
+        Feed otherFeed = createFeedWithImage(other);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + myToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(myFeed.getId().intValue()))))
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.hasItem(otherFeed.getId().intValue())));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - 비로그인 시 전체 피드 표시")
+    void getFeedList_v2_noAuth_showsAllFeeds() throws Exception {
+        // given
+        User user1 = createUser();
+        User user2 = createUser();
+        Feed feed1 = createFeedWithImage(user1);
+        Feed feed2 = createFeedWithImage(user2);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.hasItems(feed1.getId().intValue(), feed2.getId().intValue())));
     }
 
     // ===== Helper Methods =====

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -903,6 +903,33 @@ class FeedControllerTest {
     }
 
     @Test
+    @DisplayName("[V2] 피드 등록 실패 - 호스트 없는 URL이면 400")
+    void createFeed_v2_linkWithoutHost_returns400() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        FeedCreateRequestV2 request = new FeedCreateRequestV2(
+                FeedCategory.FOOD,
+                8000L,
+                "호스트 없는 링크",
+                List.of("feeds/image1.jpg"),
+                1080,
+                1350,
+                "https://foo",  // 점 없는 호스트
+                null
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("COMMON_400"));
+    }
+
+    @Test
     @DisplayName("[V2] 피드 등록 실패 - title 40자 초과면 400")
     void createFeed_v2_titleTooLong_returns400() throws Exception {
         // given

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
@@ -664,7 +664,7 @@ class FeedServiceTest {
         User user = createUser();
         List<String> images = List.of("img1.jpg", "img2.jpg", "img3.jpg");
         FeedCreateCommand command = new FeedCreateCommand(
-                user, "내용", 5000L, FeedCategory.ELECTRONICS, 100, 100, images
+                user, "내용", 5000L, FeedCategory.ELECTRONICS, 100, 100, images, null, null
         );
 
         // when
@@ -683,7 +683,7 @@ class FeedServiceTest {
         User user = createUser();
         List<String> images = List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg");
         FeedCreateCommand command = new FeedCreateCommand(
-                user, "내용", 5000L, FeedCategory.FASHION, 100, 100, images
+                user, "내용", 5000L, FeedCategory.FASHION, 100, 100, images, null, null
         );
 
         // when & then
@@ -700,7 +700,9 @@ class FeedServiceTest {
                 FeedCategory.FASHION,
                 300,
                 400,
-                List.of("feeds/test-image.jpg")
+                List.of("feeds/test-image.jpg"),
+                null,
+                null
         );
         return feedService.createFeed(command);
     }

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
@@ -54,7 +54,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 1080,
                 720,
-                List.of("feeds/abc.jpg") // List로 변경
+                List.of("feeds/abc.jpg"),
+                null,
+                null
         );
 
         Feed savedFeed = Feed.builder()
@@ -100,7 +102,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                Collections.emptyList()
+                Collections.emptyList(),
+                null,
+                null
         );
 
         // when & then
@@ -120,13 +124,13 @@ class FeedServiceUnitTest {
         // 1. null 원소가 포함된 경우
         FeedCreateCommand commandWithNull = new FeedCreateCommand(
                 user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
-                Collections.singletonList(null)
+                Collections.singletonList(null), null, null
         );
 
         // 2. 공백 원소가 포함된 경우
         FeedCreateCommand commandWithBlank = new FeedCreateCommand(
                 user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
-                List.of("  ")
+                List.of("  "), null, null
         );
 
         // when & then
@@ -154,7 +158,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg") // 4개 전달
+                List.of("1.jpg", "2.jpg", "3.jpg", "4.jpg"), // 4개 전달
+                null,
+                null
         );
 
         // when & then
@@ -179,7 +185,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                List.of("feeds/1.jpg", "feeds/2.jpg")
+                List.of("feeds/1.jpg", "feeds/2.jpg"),
+                null,
+                null
         );
 
         // when & then
@@ -203,6 +211,8 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
+                null,
+                null,
                 null
         );
 
@@ -227,7 +237,9 @@ class FeedServiceUnitTest {
                 FeedCategory.FOOD,
                 100,
                 100,
-                List.of("feeds/1.jpg", "feeds/2.jpg")
+                List.of("feeds/1.jpg", "feeds/2.jpg"),
+                null,
+                null
         );
 
         Feed savedFeed = spy(Feed.builder()

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceUnitTest.java
@@ -268,6 +268,48 @@ class FeedServiceUnitTest {
     }
 
     @Test
+    @DisplayName("피드 생성 실패 - 유효하지 않은 link(호스트 없는 URL)면 FEED_INVALID_LINK")
+    void createFeed_invalidLink_throws() {
+        // given
+        User user = User.builder().socialId("x").nickname("n").build();
+
+        FeedCreateCommand command = new FeedCreateCommand(
+                user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
+                List.of("feeds/1.jpg"),
+                "https://foo",  // 점 없는 호스트 → 유효하지 않은 URL
+                null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(command))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_INVALID_LINK);
+
+        verifyNoInteractions(feedRepository);
+    }
+
+    @Test
+    @DisplayName("피드 생성 실패 - title 40자 초과면 FEED_TITLE_TOO_LONG")
+    void createFeed_titleTooLong_throws() {
+        // given
+        User user = User.builder().socialId("x").nickname("n").build();
+
+        FeedCreateCommand command = new FeedCreateCommand(
+                user, "내용", 10000L, FeedCategory.FOOD, 100, 100,
+                List.of("feeds/1.jpg"),
+                null,
+                "a".repeat(41)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> feedService.createFeed(command))
+                .isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_TITLE_TOO_LONG);
+
+        verifyNoInteractions(feedRepository);
+    }
+
+    @Test
     @DisplayName("삭제된 피드 제외 전체 조회 성공")
     void findAllExceptDeleted_success() {
         // given


### PR DESCRIPTION
### 🚀 Issue Number
#107 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#107-feed-link-title` → `develop`

### 🔎 작업 내용
**Feed 엔티티 확장**                                                                                                                                      
- `link` 필드 추가 (`@Column(length = 500)`, nullable)                                                                                                    
- `title` 필드 추가 (`@Column(length = 40)`, nullable)                                                                                                    
- `FeedCreateCommand`에 `link`, `title` 추가 (v1 호출부는 null 전달로 하위 호환 유지)                                                                     
                                                                                                                                                          
**URL 커스텀 검증**                                                                                                                                
- `@ValidUrl` 어노테이션 + `UrlValidator` 클래스 신규 생성
- http/https 스킴만 허용, 공백 및 한글 도메인 불가                                                                                                        
- `null`/빈 값은 통과 (선택 필드이므로 필수 여부는 `@NotBlank`로 분리)
                                                                                                                                                          
**v2 피드 등록 API 수정** (`POST /api/v2/feeds`)                                                                                                          
- `FeedCreateRequestV2`에 선택 필드 `link`(@ValidUrl), `title`(@Size(max=40)) 추가
                                                                                                                                                          
**v2 피드 조회 API 수정** (`GET /api/v2/feeds`, `GET /api/v2/feeds/{feedId}`)                                                                             
- `FeedResponseV2`에 `link`, `title` 포함하여 응답에 반영                                                                                                 
- 로그인 사용자 요청 시 본인이 작성한 피드 자동 제외                                                                                                      
  - 기존 차단 사용자 필터링(`excludedUserIds`)에 `user.getId()` 추가하는 방식으로 구현                                                                    
  - 비로그인 시에는 전체 피드 조회 (기존 동작 유지)                                                                                                       
                                                                                                                                                          
**알림 응답 확장**                                        
- `NotificationResponse`에 `feedTitle` 필드 추가                                                                                                          
- `NotificationFacade`에서 `feed.getTitle()` 을 응답에 포함하도록 수정                                                                                                  

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `FeedControllerTest.java` | ✅ Pass |
| `FeedServiceTest.java` | ✅ Pass |
| `FeedServiceUnitTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 피드 작성 시 링크와 제목 추가 지원
  * 피드 상세 및 목록 응답에 링크와 제목 표시
  * 알림에 피드 제목 포함

* **유효성 검사**
  * 링크는 http/https 형식과 도메인 검증 적용
  * 제목은 최대 40자 제한 및 검증 적용

* **테스트**
  * 링크·제목 관련 유효성 및 생성/조회 테스트 추가

* **문서**
  * README 테스트 커버리지 배지 수치 업데이트 (82.0% → 82.3%)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->