### PR TITLE
[FEATURE] #112 피드 목록 및 내 피드 조회 시 category 파라미터 적용

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedController.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedController.java
@@ -7,6 +7,7 @@ import com.nexters.sseotdabwa.api.feeds.facade.FeedFacade;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -39,9 +40,10 @@ public class FeedController implements FeedControllerSpec {
             @CurrentUser User user,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Integer size,
-            @RequestParam(required = false) FeedStatus feedStatus
+            @RequestParam(required = false) FeedStatus feedStatus,
+            @RequestParam(required = false) FeedCategory category
     ) {
-        CursorPageResponse<FeedResponse> response = feedFacade.getFeedList(user, cursor, size, feedStatus);
+        CursorPageResponse<FeedResponse> response = feedFacade.getFeedList(user, cursor, size, feedStatus, category);
         return ApiResponse.success(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpec.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpec.java
@@ -5,6 +5,7 @@ import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateResponse;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedResponse;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -64,7 +65,8 @@ public interface FeedControllerSpec {
             @Parameter(hidden = true) User user,
             @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
-            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus,
+            @Parameter(description = "카테고리 필터 (미지정 시 전체)") FeedCategory category
     );
 
     @Operation(

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpecV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerSpecV2.java
@@ -5,6 +5,7 @@ import com.nexters.sseotdabwa.api.feeds.dto.FeedCreateResponse;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -52,7 +53,8 @@ public interface FeedControllerSpecV2 {
             @Parameter(hidden = true) User user,
             @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
-            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus,
+            @Parameter(description = "카테고리 필터 (미지정 시 전체)") FeedCategory category
     );
 
     @Operation(

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerV2.java
@@ -7,6 +7,7 @@ import com.nexters.sseotdabwa.api.feeds.facade.FeedFacade;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -39,9 +40,10 @@ public class FeedControllerV2 implements FeedControllerSpecV2 {
             @CurrentUser User user,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Integer size,
-            @RequestParam(required = false) FeedStatus feedStatus
+            @RequestParam(required = false) FeedStatus feedStatus,
+            @RequestParam(required = false) FeedCategory category
     ) {
-        CursorPageResponse<FeedResponseV2> response = feedFacade.getFeedListV2(user, cursor, size, feedStatus);
+        CursorPageResponse<FeedResponseV2> response = feedFacade.getFeedListV2(user, cursor, size, feedStatus, category);
         return ApiResponse.success(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
@@ -15,6 +15,7 @@ import com.nexters.sseotdabwa.common.exception.GlobalException;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.entity.FeedImage;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.feeds.exception.FeedErrorCode;
 import com.nexters.sseotdabwa.domain.feeds.service.FeedImageService;
@@ -106,14 +107,14 @@ public class FeedFacade {
      * 피드 리스트 조회 (V1: 피드당 첫 번째 이미지 단건 반환, 커서 기반 페이지네이션)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<FeedResponse> getFeedList(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+    public CursorPageResponse<FeedResponse> getFeedList(User user, Long cursor, Integer size, FeedStatus feedStatus, FeedCategory category) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
         List<Long> excludedUserIds = (user != null)
                 ? userBlockService.findBlockedUserIds(user.getId())
                 : Collections.emptyList();
 
-        List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, excludedUserIds);
+        List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, category, excludedUserIds);
 
         boolean hasNext = feeds.size() > pageSize;
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
@@ -209,7 +210,7 @@ public class FeedFacade {
      * 피드 리스트 조회 (V2: 다중 이미지 반환, 커서 기반 페이지네이션)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<FeedResponseV2> getFeedListV2(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+    public CursorPageResponse<FeedResponseV2> getFeedListV2(User user, Long cursor, Integer size, FeedStatus feedStatus, FeedCategory category) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
         List<Long> excludedUserIds;
@@ -220,7 +221,7 @@ public class FeedFacade {
             excludedUserIds = Collections.emptyList();
         }
 
-        List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, excludedUserIds);
+        List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, category, excludedUserIds);
 
         boolean hasNext = feeds.size() > pageSize;
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserController.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserController.java
@@ -9,6 +9,7 @@ import com.nexters.sseotdabwa.api.users.facade.UserFacade;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -56,9 +57,10 @@ public class UserController implements UserControllerSpec {
             @CurrentUser User user,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Integer size,
-            @RequestParam(required = false) FeedStatus feedStatus
+            @RequestParam(required = false) FeedStatus feedStatus,
+            @RequestParam(required = false) FeedCategory category
     ) {
-        CursorPageResponse<FeedResponse> response = userFacade.getMyFeeds(user, cursor, size, feedStatus);
+        CursorPageResponse<FeedResponse> response = userFacade.getMyFeeds(user, cursor, size, feedStatus, category);
         return ApiResponse.success(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpec.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpec.java
@@ -8,6 +8,7 @@ import com.nexters.sseotdabwa.api.users.dto.UserResponse;
 import com.nexters.sseotdabwa.api.users.dto.UserWithdrawResponse;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 import com.nexters.sseotdabwa.api.users.dto.BlockedUserResponse;
@@ -75,7 +76,8 @@ public interface UserControllerSpec {
             @Parameter(hidden = true) User user,
             @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
-            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus,
+            @Parameter(description = "카테고리 필터 (미지정 시 전체)") FeedCategory category
     );
 
     @Operation(

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpecV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpecV2.java
@@ -3,6 +3,7 @@ package com.nexters.sseotdabwa.api.users.controller;
 import com.nexters.sseotdabwa.api.feeds.dto.FeedResponseV2;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -28,6 +29,7 @@ public interface UserControllerSpecV2 {
             @Parameter(hidden = true) User user,
             @Parameter(description = "이전 페이지 마지막 feedId (첫 페이지는 생략)") Long cursor,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 50)") Integer size,
-            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus
+            @Parameter(description = "피드 상태 필터 (OPEN, CLOSED / 미지정 시 전체)") FeedStatus feedStatus,
+            @Parameter(description = "카테고리 필터 (미지정 시 전체)") FeedCategory category
     );
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerV2.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerV2.java
@@ -5,6 +5,7 @@ import com.nexters.sseotdabwa.api.users.facade.UserFacade;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.common.security.CurrentUser;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 
@@ -25,9 +26,10 @@ public class UserControllerV2 implements UserControllerSpecV2 {
             @CurrentUser User user,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Integer size,
-            @RequestParam(required = false) FeedStatus feedStatus
+            @RequestParam(required = false) FeedStatus feedStatus,
+            @RequestParam(required = false) FeedCategory category
     ) {
-        CursorPageResponse<FeedResponseV2> response = userFacade.getMyFeedsV2(user, cursor, size, feedStatus);
+        CursorPageResponse<FeedResponseV2> response = userFacade.getMyFeedsV2(user, cursor, size, feedStatus, category);
         return ApiResponse.success(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
@@ -20,6 +20,7 @@ import com.nexters.sseotdabwa.common.config.AwsProperties;
 import com.nexters.sseotdabwa.common.response.CursorPageResponse;
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.entity.FeedImage;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.feeds.service.FeedImageService;
 import com.nexters.sseotdabwa.domain.feeds.service.FeedReviewService;
@@ -91,10 +92,10 @@ public class UserFacade {
      * 내 피드 조회 (커서 기반 페이지네이션)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<FeedResponse> getMyFeeds(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+    public CursorPageResponse<FeedResponse> getMyFeeds(User user, Long cursor, Integer size, FeedStatus feedStatus, FeedCategory category) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
-        List<Feed> feeds = feedService.findByUserIdWithCursor(user.getId(), cursor, pageSize, feedStatus);
+        List<Feed> feeds = feedService.findByUserIdWithCursor(user.getId(), cursor, pageSize, feedStatus, category);
 
         boolean hasNext = feeds.size() > pageSize;
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;
@@ -131,10 +132,10 @@ public class UserFacade {
      * 내 피드 조회 V2 (커서 기반 페이지네이션, 다중 이미지 반환)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<FeedResponseV2> getMyFeedsV2(User user, Long cursor, Integer size, FeedStatus feedStatus) {
+    public CursorPageResponse<FeedResponseV2> getMyFeedsV2(User user, Long cursor, Integer size, FeedStatus feedStatus, FeedCategory category) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
-        List<Feed> feeds = feedService.findByUserIdWithCursor(user.getId(), cursor, pageSize, feedStatus);
+        List<Feed> feeds = feedService.findByUserIdWithCursor(user.getId(), cursor, pageSize, feedStatus, category);
 
         boolean hasNext = feeds.size() > pageSize;
         List<Feed> slicedFeeds = hasNext ? feeds.subList(0, pageSize) : feeds;

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus;
 
@@ -31,71 +32,56 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     List<Feed> findByUserIdOrderByCreatedAtDesc(Long userId);
 
-    List<Feed> findByReportStatusNotOrderByCreatedAtDescIdDesc(ReportStatus reportStatus, Pageable pageable);
+    // ===== 커서 기반 피드 목록 조회 (전체 공개 피드) =====
 
-    List<Feed> findByIdLessThanAndReportStatusNotOrderByCreatedAtDescIdDesc(Long id, ReportStatus reportStatus, Pageable pageable);
-
-    List<Feed> findByFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
-
-    List<Feed> findByIdLessThanAndFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(Long id, FeedStatus feedStatus, ReportStatus reportStatus, Pageable pageable);
-
-    List<Feed> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
-
-    List<Feed> findByUserIdAndIdLessThanOrderByCreatedAtDescIdDesc(Long userId, Long id, Pageable pageable);
-
-    List<Feed> findByUserIdAndFeedStatusOrderByCreatedAtDescIdDesc(Long userId, FeedStatus feedStatus, Pageable pageable);
-
-    List<Feed> findByUserIdAndIdLessThanAndFeedStatusOrderByCreatedAtDescIdDesc(Long userId, Long id, FeedStatus feedStatus, Pageable pageable);
-
-    // ===== NOT IN 차단 필터 조합 (Case A~D) =====
-
-    // Case A: 커서 없음, feedStatus 없음
     @Query("""
         SELECT f FROM Feed f
-        WHERE f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
-          AND f.user.id NOT IN :excludedUserIds
-        ORDER BY f.createdAt DESC, f.id DESC
-    """)
-    List<Feed> findByReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(
-            @Param("excludedUserIds") List<Long> excludedUserIds, Pageable pageable);
-
-    // Case B: 커서 있음, feedStatus 없음
-    @Query("""
-        SELECT f FROM Feed f
-        WHERE f.id < :cursor
+        WHERE (:cursorId IS NULL OR f.id < :cursorId)
+          AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
+          AND (:category IS NULL OR f.category = :category)
           AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
-          AND f.user.id NOT IN :excludedUserIds
-        ORDER BY f.createdAt DESC, f.id DESC
+        ORDER BY f.id DESC
     """)
-    List<Feed> findByIdLessThanAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(
-            @Param("cursor") Long cursor,
-            @Param("excludedUserIds") List<Long> excludedUserIds, Pageable pageable);
-
-    // Case C: 커서 없음, feedStatus 있음
-    @Query("""
-        SELECT f FROM Feed f
-        WHERE f.feedStatus = :feedStatus
-          AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
-          AND f.user.id NOT IN :excludedUserIds
-        ORDER BY f.createdAt DESC, f.id DESC
-    """)
-    List<Feed> findByFeedStatusAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(
+    List<Feed> findFeedsWithCursor(
+            @Param("cursorId") Long cursorId,
             @Param("feedStatus") FeedStatus feedStatus,
-            @Param("excludedUserIds") List<Long> excludedUserIds, Pageable pageable);
+            @Param("category") FeedCategory category,
+            Pageable pageable);
 
-    // Case D: 커서 있음, feedStatus 있음
+    // ===== 커서 기반 피드 목록 조회 (특정 유저 제외) =====
+
     @Query("""
         SELECT f FROM Feed f
-        WHERE f.id < :cursor
-          AND f.feedStatus = :feedStatus
+        WHERE (:cursorId IS NULL OR f.id < :cursorId)
+          AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
+          AND (:category IS NULL OR f.category = :category)
           AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
           AND f.user.id NOT IN :excludedUserIds
-        ORDER BY f.createdAt DESC, f.id DESC
+        ORDER BY f.id DESC
     """)
-    List<Feed> findByIdLessThanAndFeedStatusAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(
-            @Param("cursor") Long cursor,
+    List<Feed> findFeedsWithCursorExcludingUsers(
+            @Param("cursorId") Long cursorId,
             @Param("feedStatus") FeedStatus feedStatus,
-            @Param("excludedUserIds") List<Long> excludedUserIds, Pageable pageable);
+            @Param("category") FeedCategory category,
+            @Param("excludedUserIds") List<Long> excludedUserIds,
+            Pageable pageable);
+
+    // ===== 내 피드 커서 기반 조회 =====
+
+    @Query("""
+        SELECT f FROM Feed f
+        WHERE f.user.id = :userId
+          AND (:cursorId IS NULL OR f.id < :cursorId)
+          AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
+          AND (:category IS NULL OR f.category = :category)
+        ORDER BY f.id DESC
+    """)
+    List<Feed> findMyFeedsWithCursor(
+            @Param("userId") Long userId,
+            @Param("cursorId") Long cursorId,
+            @Param("feedStatus") FeedStatus feedStatus,
+            @Param("category") FeedCategory category,
+            Pageable pageable);
 
     @Modifying
     @Query("UPDATE Feed f SET f.feedStatus = 'CLOSED', f.updatedAt = :now WHERE f.feedStatus = 'OPEN' AND f.createdAt < :cutoff")

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nexters.sseotdabwa.domain.feeds.exception.FeedErrorCode;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedStatus;
 import com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus;
 import com.nexters.sseotdabwa.common.exception.GlobalException;
@@ -133,53 +134,26 @@ public class FeedService {
         return feedRepository.findByReportStatusNotOrderByCreatedAtDesc(ReportStatus.DELETED);
     }
 
-    public List<Feed> findAllExceptDeletedWithCursor(Long cursor, int size, FeedStatus feedStatus) {
+    public List<Feed> findAllExceptDeletedWithCursor(Long cursor, int size, FeedStatus feedStatus, FeedCategory category) {
         Pageable pageable = PageRequest.ofSize(size + 1);
-        if (feedStatus != null) {
-            if (cursor == null) {
-                return feedRepository.findByFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(feedStatus, ReportStatus.DELETED, pageable);
-            }
-            return feedRepository.findByIdLessThanAndFeedStatusAndReportStatusNotOrderByCreatedAtDescIdDesc(cursor, feedStatus, ReportStatus.DELETED, pageable);
-        }
-        if (cursor == null) {
-            return feedRepository.findByReportStatusNotOrderByCreatedAtDescIdDesc(ReportStatus.DELETED, pageable);
-        }
-        return feedRepository.findByIdLessThanAndReportStatusNotOrderByCreatedAtDescIdDesc(cursor, ReportStatus.DELETED, pageable);
+        return feedRepository.findFeedsWithCursor(cursor, feedStatus, category, pageable);
     }
 
-    public List<Feed> findAllExceptDeletedWithCursor(Long cursor, int size, FeedStatus feedStatus, List<Long> excludedUserIds) {
-        if (excludedUserIds == null || excludedUserIds.isEmpty()) {
-            return findAllExceptDeletedWithCursor(cursor, size, feedStatus);
-        }
+    public List<Feed> findAllExceptDeletedWithCursor(Long cursor, int size, FeedStatus feedStatus, FeedCategory category, List<Long> excludedUserIds) {
         Pageable pageable = PageRequest.ofSize(size + 1);
-        if (feedStatus != null) {
-            if (cursor == null) {
-                return feedRepository.findByFeedStatusAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(feedStatus, excludedUserIds, pageable);
-            }
-            return feedRepository.findByIdLessThanAndFeedStatusAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(cursor, feedStatus, excludedUserIds, pageable);
+        if (excludedUserIds == null || excludedUserIds.isEmpty()) {
+            return feedRepository.findFeedsWithCursor(cursor, feedStatus, category, pageable);
         }
-        if (cursor == null) {
-            return feedRepository.findByReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(excludedUserIds, pageable);
-        }
-        return feedRepository.findByIdLessThanAndReportStatusNotAndUserIdNotInOrderByCreatedAtDescIdDesc(cursor, excludedUserIds, pageable);
+        return feedRepository.findFeedsWithCursorExcludingUsers(cursor, feedStatus, category, excludedUserIds, pageable);
     }
 
     public List<Feed> findByUserIdOrderByCreatedAtDesc(Long userId) {
         return feedRepository.findByUserIdOrderByCreatedAtDesc(userId);
     }
 
-    public List<Feed> findByUserIdWithCursor(Long userId, Long cursor, int size, FeedStatus feedStatus) {
+    public List<Feed> findByUserIdWithCursor(Long userId, Long cursor, int size, FeedStatus feedStatus, FeedCategory category) {
         Pageable pageable = PageRequest.ofSize(size + 1);
-        if (feedStatus != null) {
-            if (cursor == null) {
-                return feedRepository.findByUserIdAndFeedStatusOrderByCreatedAtDescIdDesc(userId, feedStatus, pageable);
-            }
-            return feedRepository.findByUserIdAndIdLessThanAndFeedStatusOrderByCreatedAtDescIdDesc(userId, cursor, feedStatus, pageable);
-        }
-        if (cursor == null) {
-            return feedRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId, pageable);
-        }
-        return feedRepository.findByUserIdAndIdLessThanOrderByCreatedAtDescIdDesc(userId, cursor, pageable);
+        return feedRepository.findMyFeedsWithCursor(userId, cursor, feedStatus, category, pageable);
     }
 
     @Transactional

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -1006,6 +1006,42 @@ class FeedControllerTest {
                         org.hamcrest.Matchers.hasItems(feed1.getId().intValue(), feed2.getId().intValue())));
     }
 
+    @Test
+    @DisplayName("피드 리스트 조회 - category 필터 적용")
+    void getFeedList_filterByCategory() throws Exception {
+        // given
+        User user = createUser();
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+        feedImageRepository.save(FeedImage.builder().feed(fashionFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+        feedImageRepository.save(FeedImage.builder().feed(foodFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/feeds")
+                        .param("category", "FASHION"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].feedId").value(fashionFeed.getId()));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - category 필터 적용")
+    void getFeedList_v2_filterByCategory() throws Exception {
+        // given
+        User user = createUser();
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+        feedImageRepository.save(FeedImage.builder().feed(fashionFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+        feedImageRepository.save(FeedImage.builder().feed(foodFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds")
+                        .param("category", "FOOD"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].feedId").value(foodFeed.getId()));
+    }
+
     // ===== Helper Methods =====
 
     private User createUser() {

--- a/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
@@ -80,6 +80,30 @@ class UserControllerTest {
     private JwtTokenService jwtTokenService;
 
     @Test
+    @DisplayName("내 정보 조회 성공 - 200 OK")
+    void getMyInfo_success() throws Exception {
+        // given
+        User user = createUser();
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"))
+                .andExpect(jsonPath("$.data.nickname").value(user.getNickname()))
+                .andExpect(jsonPath("$.data.socialAccount").value(user.getSocialAccount().name()));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 실패 - 비로그인 401")
+    void getMyInfo_unauthorized_returns401() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     @DisplayName("회원 탈퇴 성공 - 닉네임 반환")
     void withdraw_success_returnsNickname() throws Exception {
         // given
@@ -287,6 +311,46 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].feedId").value(openFeed.getId()));
+    }
+
+    @Test
+    @DisplayName("내가 작성한 피드 조회 - category 필터 적용")
+    void getMyFeeds_filterByCategory() throws Exception {
+        // given
+        User user = createUser();
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+        feedImageRepository.save(FeedImage.builder().feed(fashionFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+        feedImageRepository.save(FeedImage.builder().feed(foodFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/me/feeds")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("category", "FASHION"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].feedId").value(fashionFeed.getId()));
+    }
+
+    @Test
+    @DisplayName("[V2] 내가 작성한 피드 조회 - category 필터 적용")
+    void getMyFeeds_v2_filterByCategory() throws Exception {
+        // given
+        User user = createUser();
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+        feedImageRepository.save(FeedImage.builder().feed(fashionFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+        feedImageRepository.save(FeedImage.builder().feed(foodFeed).s3ObjectKey("f.jpg").imageWidth(10).imageHeight(10).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/users/me/feeds")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("category", "FOOD"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].feedId").value(foodFeed.getId()));
     }
 
     private User createUser() {

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
@@ -273,7 +273,7 @@ class FeedServiceTest {
         Feed feed3 = createFeed(user);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 2, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 2, null, null);
 
         // then
         assertThat(result).hasSize(3); // size+1 = 3건 조회
@@ -290,7 +290,7 @@ class FeedServiceTest {
         Feed feed3 = createFeed(user);
 
         // when - feed3의 ID를 커서로 지정하면 feed3보다 작은 ID만
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(feed3.getId(), 2, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(feed3.getId(), 2, null, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -306,7 +306,7 @@ class FeedServiceTest {
         Feed feed1 = createFeed(user);
 
         // when - size=5 요청했지만 1건만 존재
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 5, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 5, null, null);
 
         // then
         assertThat(result).hasSize(1);
@@ -323,7 +323,7 @@ class FeedServiceTest {
         feedRepository.save(deletedFeed);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -335,7 +335,7 @@ class FeedServiceTest {
     @DisplayName("커서 페이지네이션 - 피드 없을 때 빈 리스트")
     void findAllExceptDeletedWithCursor_emptyResult() {
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null);
 
         // then
         assertThat(result).isEmpty();
@@ -352,7 +352,7 @@ class FeedServiceTest {
         feedRepository.save(closedFeed);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.OPEN);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.OPEN, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -371,7 +371,7 @@ class FeedServiceTest {
         feedRepository.save(closedFeed);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.CLOSED);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.CLOSED, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -390,7 +390,7 @@ class FeedServiceTest {
         feedRepository.save(closedFeed);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -407,7 +407,7 @@ class FeedServiceTest {
         Feed open3 = createFeed(user);
 
         // when - open3의 ID를 커서로, OPEN 필터
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(open3.getId(), 10, FeedStatus.OPEN);
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(open3.getId(), 10, FeedStatus.OPEN, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -429,7 +429,7 @@ class FeedServiceTest {
         Feed feed3 = createFeed(user);
 
         // when
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 2, null);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 2, null, null);
 
         // then
         assertThat(result).hasSize(3); // size+1 = 3건 조회
@@ -446,7 +446,7 @@ class FeedServiceTest {
         Feed feed3 = createFeed(user);
 
         // when - feed3의 ID를 커서로 지정하면 feed3보다 작은 ID만
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), feed3.getId(), 2, null);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), feed3.getId(), 2, null, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -462,7 +462,7 @@ class FeedServiceTest {
         Feed feed1 = createFeed(user);
 
         // when - size=5 요청했지만 1건만 존재
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 5, null);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 5, null, null);
 
         // then
         assertThat(result).hasSize(1);
@@ -478,7 +478,7 @@ class FeedServiceTest {
         Feed otherFeed = createFeed(otherUser);
 
         // when
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, null);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, null, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -493,7 +493,7 @@ class FeedServiceTest {
         User user = createUser();
 
         // when
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, null);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, null, null);
 
         // then
         assertThat(result).isEmpty();
@@ -510,7 +510,7 @@ class FeedServiceTest {
         feedRepository.save(closedFeed);
 
         // when
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, FeedStatus.OPEN);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, FeedStatus.OPEN, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -529,7 +529,7 @@ class FeedServiceTest {
         feedRepository.save(closedFeed);
 
         // when
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, FeedStatus.CLOSED);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, FeedStatus.CLOSED, null);
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -547,7 +547,7 @@ class FeedServiceTest {
         Feed open3 = createFeed(user);
 
         // when - open3의 ID를 커서로, OPEN 필터
-        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), open3.getId(), 10, FeedStatus.OPEN);
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), open3.getId(), 10, FeedStatus.OPEN, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -569,7 +569,7 @@ class FeedServiceTest {
         Feed blockedFeed = createFeed(blockedUser);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, List.of(blockedUser.getId()));
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null, List.of(blockedUser.getId()));
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -587,7 +587,7 @@ class FeedServiceTest {
         Feed feed2 = createFeed(other);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, List.of());
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null, List.of());
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -607,7 +607,7 @@ class FeedServiceTest {
         Feed feed3 = createFeed(user);
 
         // when - feed3을 커서로, blockedUser 차단
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(feed3.getId(), 10, null, List.of(blockedUser.getId()));
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(feed3.getId(), 10, null, null, List.of(blockedUser.getId()));
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -626,7 +626,7 @@ class FeedServiceTest {
         Feed blockedOpenFeed = createFeed(blockedUser);
 
         // when
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.OPEN, List.of(blockedUser.getId()));
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, FeedStatus.OPEN, null, List.of(blockedUser.getId()));
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -646,7 +646,7 @@ class FeedServiceTest {
         Feed open3 = createFeed(user);
 
         // when - open3을 커서로, OPEN 필터, blockedUser 차단
-        List<Feed> result = feedService.findAllExceptDeletedWithCursor(open3.getId(), 10, FeedStatus.OPEN, List.of(blockedUser.getId()));
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(open3.getId(), 10, FeedStatus.OPEN, null, List.of(blockedUser.getId()));
 
         // then
         assertThat(result).extracting(Feed::getId)
@@ -656,6 +656,56 @@ class FeedServiceTest {
             assertThat(f.getId()).isLessThan(open3.getId());
             assertThat(f.getFeedStatus()).isEqualTo(FeedStatus.OPEN);
         });
+    }
+
+    @Test
+    @DisplayName("카테고리 필터 - 특정 카테고리만 반환")
+    void findAllExceptDeletedWithCursor_filterByCategory() {
+        // given
+        User user = createUser();
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+
+        // when
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, FeedCategory.FASHION);
+
+        // then
+        assertThat(result).extracting(Feed::getId)
+                .contains(fashionFeed.getId())
+                .doesNotContain(foodFeed.getId());
+    }
+
+    @Test
+    @DisplayName("카테고리 필터 - null이면 전체 카테고리 반환")
+    void findAllExceptDeletedWithCursor_nullCategory_returnsAll() {
+        // given
+        User user = createUser();
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+
+        // when
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null);
+
+        // then
+        assertThat(result).extracting(Feed::getId)
+                .containsExactlyInAnyOrder(fashionFeed.getId(), foodFeed.getId());
+    }
+
+    @Test
+    @DisplayName("내 피드 카테고리 필터")
+    void findByUserIdWithCursor_filterByCategory() {
+        // given
+        User user = createUser();
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(user).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        Feed foodFeed = feedRepository.save(Feed.builder().user(user).content("음식").price(1000L).category(FeedCategory.FOOD).build());
+
+        // when
+        List<Feed> result = feedService.findByUserIdWithCursor(user.getId(), null, 10, null, FeedCategory.FASHION);
+
+        // then
+        assertThat(result).extracting(Feed::getId)
+                .contains(fashionFeed.getId())
+                .doesNotContain(foodFeed.getId());
     }
 
     @Test


### PR DESCRIPTION
### 🚀 Issue Number
#112 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#112-category-filtering` → `develop`

### 🔎 작업 내용
**피드 리스트 조회 카테고리 필터링**
- 피드 리스트 조회 API ( GET /api/v1/feeds, GET /api/v2/feeds )에 category 쿼리 파라미터 추가
- category 값이 없으면 기존과 동일하게 전체 카테고리 조회
- category 값이 있으면 해당 카테고리의 피드만 필터링하여 반환
  - 지원 카테고리: LUXURY, FASHION, BEAUTY, FOOD, ELECTRONICS, TRAVEL, HEALTH, BOOK, ETC

**내가 작성한 피드 조회 카테고리 필터링**
- 내가 작성한 피드 조회 API ( GET /api/v1/users/me/feeds, GET /api/v2/users/me/feeds )에도 동일한 category 쿼리 파라미터 적용

 
### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `FeedControllerTest.java` | ✅ Pass |
| `FeedServiceTest.java` | ✅ Pass |
| `UserControllerTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 피드 목록과 내 피드에서 카테고리 필터링 기능 추가
* 피드 조회 시 특정 카테고리별로 필터링하여 원하는 콘텐츠를 더 쉽게 찾을 수 있음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->