### PR TITLE
[REFACTOR] #117 신고된 피드 목록 노출 제거 및 투표 만료 시 CLOSED 처리

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/repository/FeedRepository.java
@@ -34,7 +34,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
         SELECT f FROM Feed f
         WHERE (:cursorId IS NULL OR f.id < :cursorId)
           AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
-          AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
+          AND f.reportStatus NOT IN (
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED,
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.REPORTED
+          )
         ORDER BY f.id DESC
     """)
     List<Feed> findFeedsWithCursor(
@@ -47,7 +50,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
         WHERE (:cursorId IS NULL OR f.id < :cursorId)
           AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
           AND f.category IN :categories
-          AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
+          AND f.reportStatus NOT IN (
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED,
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.REPORTED
+          )
         ORDER BY f.id DESC
     """)
     List<Feed> findFeedsWithCursorByCategories(
@@ -62,7 +68,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
         SELECT f FROM Feed f
         WHERE (:cursorId IS NULL OR f.id < :cursorId)
           AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
-          AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
+          AND f.reportStatus NOT IN (
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED,
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.REPORTED
+          )
           AND f.user.id NOT IN :excludedUserIds
         ORDER BY f.id DESC
     """)
@@ -77,7 +86,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
         WHERE (:cursorId IS NULL OR f.id < :cursorId)
           AND (:feedStatus IS NULL OR f.feedStatus = :feedStatus)
           AND f.category IN :categories
-          AND f.reportStatus <> com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED
+          AND f.reportStatus NOT IN (
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.DELETED,
+              com.nexters.sseotdabwa.domain.feeds.enums.ReportStatus.REPORTED
+          )
           AND f.user.id NOT IN :excludedUserIds
         ORDER BY f.id DESC
     """)
@@ -126,7 +138,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * 마감 대상 feedId 조회
      * - OPEN
      * - createdAt <= cutoff
-     * - reportStatus NOT IN (DELETED, REPORTED)
+     * - reportStatus NOT IN (DELETED)
      */
     @Query("""
         select f.id

--- a/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/feeds/service/FeedService.java
@@ -184,7 +184,7 @@ public class FeedService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime cutoff = now.minusHours(48);
 
-        List<ReportStatus> excluded = Arrays.asList(ReportStatus.DELETED, ReportStatus.REPORTED);
+        List<ReportStatus> excluded = Arrays.asList(ReportStatus.DELETED);
 
         List<Long> feedIds = feedRepository.findExpiredOpenFeedIds(cutoff, excluded);
         if (feedIds.isEmpty()) {

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -1086,6 +1086,46 @@ class FeedControllerTest {
                         org.hamcrest.Matchers.hasItems(fashionFeed.getId().intValue(), foodFeed.getId().intValue())));
     }
 
+    // ===== 신고된 피드 필터링 =====
+
+    @Test
+    @DisplayName("피드 리스트 조회 - 신고된(REPORTED) 피드 미표시")
+    void getFeedList_reportedFeedNotShown() throws Exception {
+        // given
+        User user = createUser();
+        Feed normalFeed = createFeedWithImage(user);
+        Feed reportedFeed = createFeedWithImage(user);
+        reportedFeed.report();
+        feedRepository.save(reportedFeed);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.hasItem(normalFeed.getId().intValue())))
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(reportedFeed.getId().intValue()))));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - 신고된(REPORTED) 피드 미표시")
+    void getFeedList_v2_reportedFeedNotShown() throws Exception {
+        // given
+        User user = createUser();
+        Feed normalFeed = createFeedWithImage(user);
+        Feed reportedFeed = createFeedWithImage(user);
+        reportedFeed.report();
+        feedRepository.save(reportedFeed);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.hasItem(normalFeed.getId().intValue())))
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(reportedFeed.getId().intValue()))));
+    }
+
     // ===== Helper Methods =====
 
     private User createUser() {

--- a/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/feeds/service/FeedServiceTest.java
@@ -194,6 +194,26 @@ class FeedServiceTest {
     }
 
     @Test
+    @DisplayName("REPORTED 피드 → 48시간 초과 시 CLOSED 전환 + feedId 반환")
+    void closeExpiredFeedsAndReturnIds_closesReportedExpiredFeeds() {
+        // given
+        User user = createUser();
+        Feed feed = createFeed(user);
+        feed.report();
+        feedRepository.save(feed);
+        setCreatedAt(feed.getId(), LocalDateTime.now().minusHours(49));
+
+        // when
+        List<Long> closedIds = feedService.closeExpiredFeedsAndReturnIds();
+        entityManager.clear();
+
+        // then
+        assertThat(closedIds).contains(feed.getId());
+        Feed updated = feedRepository.findById(feed.getId()).orElseThrow();
+        assertThat(updated.getFeedStatus()).isEqualTo(FeedStatus.CLOSED);
+    }
+
+    @Test
     @DisplayName("이미 CLOSED 피드 → 영향 없음 + 반환 리스트 비어있음")
     void closeExpiredFeedsAndReturnIds_ignoresAlreadyClosedFeeds() {
         // given
@@ -276,6 +296,25 @@ class FeedServiceTest {
 
         // then
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("커서 페이지네이션 - REPORTED 상태 피드 제외")
+    void findAllExceptDeletedWithCursor_excludesReported() {
+        // given
+        User user = createUser();
+        Feed normalFeed = createFeed(user);
+        Feed reportedFeed = createFeed(user);
+        reportedFeed.report();
+        feedRepository.save(reportedFeed);
+
+        // when
+        List<Feed> result = feedService.findAllExceptDeletedWithCursor(null, 10, null, null);
+
+        // then
+        assertThat(result).extracting(Feed::getId)
+                .contains(normalFeed.getId())
+                .doesNotContain(reportedFeed.getId());
     }
 
     @Test


### PR DESCRIPTION
### 🚀 Issue Number
#117 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`refactor/#117-reported-feed` → `develop`

### 🔎 작업 내용
- 피드 목록 조회 쿼리 4개 reportStatus <> DELETED → reportStatus NOT IN (DELETED, REPORTED) 변경
- closeExpiredFeedsAndReturnIds() excluded 목록에서 REPORTED 제거 → 신고된 피드도 48시간 경과 시 CLOSED 처리

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `FeedControllerTest.java` | ✅ Pass |
| `FeedServiceTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 신고된 피드가 피드 목록에서 필터링되어 표시되지 않도록 개선
  * 만료된 신고 피드도 자동 종료 처리 대상에 포함

* **테스트**
  * 신고된 피드 필터링 검증 테스트 추가
  * 피드 조회 및 종료 로직 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->