### PR TITLE
[FEATURE] #119 안읽은 알림 수 조회 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.3%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.4%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationController.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import com.nexters.sseotdabwa.api.notifications.dto.NotificationResponse;
+import com.nexters.sseotdabwa.api.notifications.dto.UnreadCountResponse;
 import com.nexters.sseotdabwa.api.notifications.facade.NotificationFacade;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.common.security.CurrentUser;
@@ -20,6 +21,12 @@ import lombok.RequiredArgsConstructor;
 public class NotificationController implements NotificationControllerSpec {
 
     private final NotificationFacade notificationFacade;
+
+    @Override
+    @GetMapping("/unread-count")
+    public ApiResponse<UnreadCountResponse> getUnreadCount(@CurrentUser User user) {
+        return ApiResponse.success(new UnreadCountResponse(notificationFacade.getUnreadCount(user)), HttpStatus.OK);
+    }
 
     @Override
     @GetMapping

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationControllerSpec.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationControllerSpec.java
@@ -3,6 +3,7 @@ package com.nexters.sseotdabwa.api.notifications.controller;
 import java.util.List;
 
 import com.nexters.sseotdabwa.api.notifications.dto.NotificationResponse;
+import com.nexters.sseotdabwa.api.notifications.dto.UnreadCountResponse;
 import com.nexters.sseotdabwa.common.response.ApiResponse;
 import com.nexters.sseotdabwa.domain.notifications.enums.NotificationType;
 import com.nexters.sseotdabwa.domain.users.entity.User;
@@ -15,6 +16,14 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Notifications", description = "알림 API")
 public interface NotificationControllerSpec {
+
+    @Operation(
+            summary = "미확인 알림 수 조회",
+            description = "읽지 않은 알림 수를 반환합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/unread-count")
+    ApiResponse<UnreadCountResponse> getUnreadCount(@Parameter(hidden = true) User user);
 
     @Operation(
             summary = "알림 리스트 조회",

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/dto/UnreadCountResponse.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/dto/UnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.nexters.sseotdabwa.api.notifications.dto;
+
+public record UnreadCountResponse(long unreadCount) {
+}

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
@@ -51,6 +51,11 @@ public class NotificationFacade {
     private final FcmSender fcmSender;
     private final AwsProperties awsProperties;
 
+    @Transactional(readOnly = true)
+    public long getUnreadCount(User user) {
+        return notificationService.countUnread(user.getId());
+    }
+
     /**
      * 최근 30일 알림 조회
      */

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/repository/NotificationRepository.java
@@ -49,5 +49,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             Pageable pageable
     );
 
+    @Query("""
+        select count(n)
+        from Notification n
+        where n.user.id = :userId
+          and n.isRead = false
+          and n.createdAt >= :cutoff
+    """)
+    long countUnreadSince(@Param("userId") Long userId, @Param("cutoff") LocalDateTime cutoff);
+
     void deleteByFeedId(Long feedId);
 }

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/service/NotificationService.java
@@ -103,6 +103,11 @@ public class NotificationService {
         }
     }
 
+    public long countUnread(Long userId) {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(RECENT_DAYS);
+        return notificationRepository.countUnreadSince(userId, cutoff);
+    }
+
     @Transactional
     public void deleteByFeed(Feed feed) {
         notificationRepository.deleteByFeedId(feed.getId());

--- a/src/test/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/notifications/controller/NotificationControllerTest.java
@@ -121,6 +121,96 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("NOTI_001"));
     }
 
+    // ===== 미확인 알림 수 조회 =====
+
+    @Test
+    @DisplayName("미확인 알림 수 조회 성공 - 읽지 않은 알림 수 반환")
+    void getUnreadCount_success() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = createFeed(user);
+
+        notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.MY_FEED_CLOSED)
+                .title("투표 종료!").body("body").build());
+        notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.PARTICIPATED_FEED_CLOSED)
+                .title("투표 종료!").body("body").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notifications/unread-count")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.unreadCount").value(2));
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 조회 - 알림 없으면 0 반환")
+    void getUnreadCount_noNotifications_returnsZero() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notifications/unread-count")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.unreadCount").value(0));
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 조회 - 읽은 알림은 카운트에서 제외")
+    void getUnreadCount_excludesReadNotifications() throws Exception {
+        // given
+        User user = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = createFeed(user);
+
+        Notification unread = notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.MY_FEED_CLOSED)
+                .title("투표 종료!").body("body").build());
+
+        Notification read = notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.PARTICIPATED_FEED_CLOSED)
+                .title("투표 종료!").body("body").build());
+        read.markAsRead();
+        notificationRepository.save(read);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notifications/unread-count")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.unreadCount").value(1));
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 조회 - 비로그인 시 401")
+    void getUnreadCount_unauthorized_401() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications/unread-count"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 조회 - 다른 유저의 알림은 카운트에서 제외")
+    void getUnreadCount_excludesOtherUsersNotifications() throws Exception {
+        // given
+        User user = createUser();
+        User otherUser = createUser();
+        String token = jwtTokenService.createAccessToken(user.getId());
+        Feed feed = createFeed(user);
+
+        notificationRepository.save(Notification.builder()
+                .user(otherUser).feed(feed).type(NotificationType.MY_FEED_CLOSED)
+                .title("투표 종료!").body("body").build());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notifications/unread-count")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.unreadCount").value(0));
+    }
+
     private User createUser() {
         return userRepository.save(User.builder()
                 .socialId(UUID.randomUUID().toString())

--- a/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
@@ -10,6 +10,7 @@ import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedImageRepository;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedRepository;
 
+import com.nexters.sseotdabwa.domain.notifications.entity.Notification;
 import com.nexters.sseotdabwa.domain.notifications.enums.NotificationType;
 import com.nexters.sseotdabwa.domain.notifications.push.FcmSender;
 import com.nexters.sseotdabwa.domain.notifications.repository.NotificationRepository;
@@ -162,6 +163,65 @@ class NotificationFacadeTest {
         // then
         assertThat(notificationRepository.count()).isEqualTo(1);
         verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    // ===== getUnreadCount =====
+
+    @Test
+    @DisplayName("미확인 알림 수 반환 - 읽지 않은 알림만 카운트")
+    void getUnreadCount_returnsOnlyUnread() {
+        // given
+        User user = createUser("user");
+        Feed feed = createFeed(user);
+
+        notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.MY_FEED_CLOSED)
+                .title("제목").body("내용").build());
+
+        Notification read = notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.PARTICIPATED_FEED_CLOSED)
+                .title("제목").body("내용").build());
+        read.markAsRead();
+        notificationRepository.save(read);
+
+        // when
+        long count = notificationFacade.getUnreadCount(user);
+
+        // then
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 반환 - 알림 없으면 0")
+    void getUnreadCount_returnsZeroWhenNone() {
+        // given
+        User user = createUser("user");
+
+        // when
+        long count = notificationFacade.getUnreadCount(user);
+
+        // then
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("미확인 알림 수 반환 - 전부 읽은 경우 0")
+    void getUnreadCount_returnsZeroWhenAllRead() {
+        // given
+        User user = createUser("user");
+        Feed feed = createFeed(user);
+
+        Notification n = notificationRepository.save(Notification.builder()
+                .user(user).feed(feed).type(NotificationType.MY_FEED_CLOSED)
+                .title("제목").body("내용").build());
+        n.markAsRead();
+        notificationRepository.save(n);
+
+        // when
+        long count = notificationFacade.getUnreadCount(user);
+
+        // then
+        assertThat(count).isZero();
     }
 
     // ---------------- helpers ----------------


### PR DESCRIPTION
### 🚀 Issue Number
#119 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#119-noti-unread` → `develop`

### 🔎 작업 내용
- GET /api/v1/notifications/unread-count 엔드포인트 추가  
    - 최근 30일 이내 isRead = false 알림 수 반환
    - 알림 목록 조회와 동일한 30일 기준 적용

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `NotificationControllerTest.java` | ✅ Pass |
| `NotificationFacadeTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 읽지 않은 알림 개수를 조회할 수 있는 새로운 API 엔드포인트(`GET /api/v1/notifications/unread-count`) 추가. 인증된 사용자의 미읽 알림 수를 실시간으로 확인할 수 있습니다.

* **테스트**
  * 새로운 엔드포인트에 대한 포괄적인 테스트 스위트 추가로 안정성 확보.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->