### PR TITLE
[FIX] #123 투표 피드(V2)에 본인이 올린 피드가 노출되도록 수정

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/feeds/facade/FeedFacade.java
@@ -214,13 +214,9 @@ public class FeedFacade {
     public CursorPageResponse<FeedResponseV2> getFeedListV2(User user, Long cursor, Integer size, FeedStatus feedStatus, List<FeedCategory> categories) {
         int pageSize = (size == null) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
-        List<Long> excludedUserIds;
-        if (user != null) {
-            excludedUserIds = new ArrayList<>(userBlockService.findBlockedUserIds(user.getId()));
-            excludedUserIds.add(user.getId());
-        } else {
-            excludedUserIds = Collections.emptyList();
-        }
+        List<Long> excludedUserIds = (user != null)
+                ? userBlockService.findBlockedUserIds(user.getId())
+                : Collections.emptyList();
 
         List<Feed> feeds = feedService.findAllExceptDeletedWithCursor(cursor, pageSize, feedStatus, categories, excludedUserIds);
 

--- a/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/feeds/controller/FeedControllerTest.java
@@ -378,7 +378,7 @@ class FeedControllerTest {
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img1.jpg").imageWidth(100).imageHeight(100).build());
         feedImageRepository.save(FeedImage.builder().feed(feed).s3ObjectKey("img2.jpg").imageWidth(200).imageHeight(200).build());
 
-        // when & then - 로그인 시 본인 피드 제외, 타인 피드는 조회됨
+        // when & then - 로그인 시 본인 피드 포함, 타인 피드도 조회됨
         mockMvc.perform(get("/api/v2/feeds")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -967,11 +967,11 @@ class FeedControllerTest {
                 .andExpect(jsonPath("$.data.title").value("살까 말까"));
     }
 
-    // ===== 피드 리스트 V2 본인 피드 제외 =====
+    // ===== 피드 리스트 V2 본인 피드 노출 =====
 
     @Test
-    @DisplayName("[V2] 피드 리스트 조회 - 로그인 시 본인 피드 자동 제외")
-    void getFeedList_v2_loggedIn_excludesMyFeeds() throws Exception {
+    @DisplayName("[V2] 피드 리스트 조회 - 로그인 시 본인 피드 포함 노출")
+    void getFeedList_v2_loggedIn_includesMyFeeds() throws Exception {
         // given
         User me = createUser();
         User other = createUser();
@@ -985,7 +985,7 @@ class FeedControllerTest {
                         .header("Authorization", "Bearer " + myToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[*].feedId",
-                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(myFeed.getId().intValue()))))
+                        org.hamcrest.Matchers.hasItem(myFeed.getId().intValue())))
                 .andExpect(jsonPath("$.data.content[*].feedId",
                         org.hamcrest.Matchers.hasItem(otherFeed.getId().intValue())));
     }
@@ -1004,6 +1004,53 @@ class FeedControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[*].feedId",
                         org.hamcrest.Matchers.hasItems(feed1.getId().intValue(), feed2.getId().intValue())));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - 차단한 사용자의 피드 미표시")
+    void getFeedList_v2_blockedUserFeedNotShown() throws Exception {
+        // given
+        User viewer = createUser();
+        User blocked = createUser();
+        String viewerToken = jwtTokenService.createAccessToken(viewer.getId());
+
+        createFeedWithImage(viewer);
+        Feed blockedFeed = createFeedWithImage(blocked);
+        userBlockRepository.save(UserBlock.builder().user(viewer).blockedUser(blocked).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(blockedFeed.getId().intValue()))));
+    }
+
+    @Test
+    @DisplayName("[V2] 피드 리스트 조회 - 카테고리 필터 + 차단 유저 동시 적용")
+    void getFeedList_v2_categoryFilter_withBlockedUser() throws Exception {
+        // given
+        User viewer = createUser();
+        User blocked = createUser();
+        String viewerToken = jwtTokenService.createAccessToken(viewer.getId());
+
+        Feed fashionFeed = feedRepository.save(Feed.builder().user(viewer).content("패션").price(1000L).category(FeedCategory.FASHION).build());
+        feedImageRepository.save(FeedImage.builder().feed(fashionFeed).s3ObjectKey("fashion.jpg").imageWidth(100).imageHeight(100).build());
+
+        Feed blockedFashionFeed = feedRepository.save(Feed.builder().user(blocked).content("차단패션").price(2000L).category(FeedCategory.FASHION).build());
+        feedImageRepository.save(FeedImage.builder().feed(blockedFashionFeed).s3ObjectKey("blocked.jpg").imageWidth(100).imageHeight(100).build());
+
+        userBlockRepository.save(UserBlock.builder().user(viewer).blockedUser(blocked).build());
+
+        // when & then
+        mockMvc.perform(get("/api/v2/feeds")
+                        .header("Authorization", "Bearer " + viewerToken)
+                        .param("category", "FASHION"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.hasItem(fashionFeed.getId().intValue())))
+                .andExpect(jsonPath("$.data.content[*].feedId",
+                        org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem(blockedFashionFeed.getId().intValue()))));
     }
 
     @Test


### PR DESCRIPTION
### 🚀 Issue Number
#123 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`fix/#123-get-feeds-including-myfeed` → `develop`

### 🔎 작업 내용
- `FeedFacade.getFeedListV2`에서 `excludedUserIds.add(user.getId())` 제거하여 V1과 동일하게 본인 피드
  노출되도록 수정
- 차단 유저 피드 제외 동작은 V1/V2 동일하게 유지

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `FeedControllerTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그인한 사용자의 피드가 이제 정상적으로 표시됩니다.
  * 차단된 사용자의 피드는 피드 목록에서 제외됩니다.

* **테스트**
  * 차단된 사용자 피드 미표시 동작을 검증하는 테스트가 추가되었습니다.
  * 카테고리 필터와 차단 기능이 함께 적용되는 시나리오를 검증하는 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nexters/BuyOrNot-BE/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->