### PR TITLE
[FIX] #124 투표 응답에 투표자 프로필 이미지(myProfileImage) 추가

### DIFF
--- a/src/main/java/com/nexters/sseotdabwa/api/votes/dto/VoteResponse.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/votes/dto/VoteResponse.java
@@ -8,15 +8,17 @@ public record VoteResponse(
         VoteChoice choice,
         Long yesCount,
         Long noCount,
-        Long totalCount
+        Long totalCount,
+        String myProfileImage
 ) {
-    public static VoteResponse of(Feed feed, VoteChoice choice) {
+    public static VoteResponse of(Feed feed, VoteChoice choice, String myProfileImage) {
         return new VoteResponse(
                 feed.getId(),
                 choice,
                 feed.getYesCount(),
                 feed.getNoCount(),
-                feed.getYesCount() + feed.getNoCount()
+                feed.getYesCount() + feed.getNoCount(),
+                myProfileImage
         );
     }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
@@ -47,7 +47,7 @@ public class VoteFacade {
         VoteCreateCommand command = new VoteCreateCommand(user, feed, choice, VoteType.USER);
         voteLogService.createVoteLog(command);
 
-        return VoteResponse.of(feed, choice);
+        return VoteResponse.of(feed, choice, user.getProfileImage());
     }
 
     @Transactional
@@ -68,6 +68,6 @@ public class VoteFacade {
         VoteCreateCommand command = new VoteCreateCommand(null, feed, choice, VoteType.SYSTEM);
         voteLogService.createVoteLog(command);
 
-        return VoteResponse.of(feed, choice);
+        return VoteResponse.of(feed, choice, null);
     }
 }

--- a/src/test/java/com/nexters/sseotdabwa/api/votes/controller/VoteControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/votes/controller/VoteControllerTest.java
@@ -59,7 +59,7 @@ class VoteControllerTest {
     void vote_success_201() throws Exception {
         // given
         User owner = createUser();
-        User voter = createUser();
+        User voter = createUserWithProfile("https://cdn.example.com/profile1.png");
         Feed feed = createFeed(owner);
         String token = jwtTokenService.createAccessToken(voter.getId());
         VoteRequest request = new VoteRequest(VoteChoice.YES);
@@ -75,7 +75,8 @@ class VoteControllerTest {
                 .andExpect(jsonPath("$.data.choice").value("YES"))
                 .andExpect(jsonPath("$.data.yesCount").value(1))
                 .andExpect(jsonPath("$.data.noCount").value(0))
-                .andExpect(jsonPath("$.data.totalCount").value(1));
+                .andExpect(jsonPath("$.data.totalCount").value(1))
+                .andExpect(jsonPath("$.data.myProfileImage").value("https://cdn.example.com/profile1.png"));
     }
 
     @Test
@@ -151,7 +152,8 @@ class VoteControllerTest {
                 .andExpect(jsonPath("$.data.choice").value("NO"))
                 .andExpect(jsonPath("$.data.yesCount").value(0))
                 .andExpect(jsonPath("$.data.noCount").value(1))
-                .andExpect(jsonPath("$.data.totalCount").value(1));
+                .andExpect(jsonPath("$.data.totalCount").value(1))
+                .andExpect(jsonPath("$.data.myProfileImage").doesNotExist());
     }
 
     @Test
@@ -179,6 +181,15 @@ class VoteControllerTest {
                 .socialId(UUID.randomUUID().toString())
                 .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
                 .socialAccount(SocialAccount.KAKAO)
+                .build());
+    }
+
+    private User createUserWithProfile(String profileImage) {
+        return userRepository.save(User.builder()
+                .socialId(UUID.randomUUID().toString())
+                .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
+                .socialAccount(SocialAccount.KAKAO)
+                .profileImage(profileImage)
                 .build());
     }
 

--- a/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
@@ -48,7 +48,7 @@ class VoteFacadeTest {
     void vote_yes_success() {
         // given
         User owner = createUser();
-        User voter = createUser();
+        User voter = createUserWithProfile("https://cdn.example.com/profile1.png");
         Feed feed = createFeed(owner);
         VoteRequest request = new VoteRequest(VoteChoice.YES);
 
@@ -61,6 +61,7 @@ class VoteFacadeTest {
         assertThat(response.yesCount()).isEqualTo(1L);
         assertThat(response.noCount()).isEqualTo(0L);
         assertThat(response.totalCount()).isEqualTo(1L);
+        assertThat(response.myProfileImage()).isEqualTo("https://cdn.example.com/profile1.png");
     }
 
     @Test
@@ -149,6 +150,7 @@ class VoteFacadeTest {
         assertThat(response.yesCount()).isEqualTo(1L);
         assertThat(response.noCount()).isEqualTo(0L);
         assertThat(response.totalCount()).isEqualTo(1L);
+        assertThat(response.myProfileImage()).isNull();
     }
 
     @Test
@@ -224,6 +226,15 @@ class VoteFacadeTest {
                 .socialId(UUID.randomUUID().toString())
                 .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
                 .socialAccount(SocialAccount.KAKAO)
+                .build());
+    }
+
+    private User createUserWithProfile(String profileImage) {
+        return userRepository.save(User.builder()
+                .socialId(UUID.randomUUID().toString())
+                .nickname("테스트_" + UUID.randomUUID().toString().substring(0, 8))
+                .socialAccount(SocialAccount.KAKAO)
+                .profileImage(profileImage)
                 .build());
     }
 


### PR DESCRIPTION
### 🚀 Issue Number
#124 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`fix/#124-add-profileimage-in-response` → `develop`

### 🔎 작업 내용
- `VoteResponse`에 `myProfileImage` 필드 추가
- `VoteFacade.vote()` — `user.getProfileImage()`를 응답에 포함하여 투표 시 프로필 이미지 노출
- `VoteFacade.guestVote()` — 비로그인이므로 `myProfileImage: null` 반환

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `VoteControllerTest.java` | ✅ Pass |
| `VoteFacadeTest.java` | ✅ Pass |