### PR TITLE
[FEATURE] #128 투표 미등록 유저 마케팅 푸시 스케줄러 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.4%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.5%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserController.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserController.java
@@ -103,4 +103,11 @@ public class UserController implements UserControllerSpec {
         userFacade.unblockUser(user, userId);
         return ApiResponse.success(HttpStatus.OK);
     }
+
+    @Override
+    @PostMapping("/app-open")
+    public ApiResponse<Void> recordAppOpen(@CurrentUser User user) {
+        userFacade.recordAppOpen(user);
+        return ApiResponse.success(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpec.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/controller/UserControllerSpec.java
@@ -136,4 +136,15 @@ public interface UserControllerSpec {
             @Parameter(hidden = true) User user,
             @Parameter(description = "차단 해제할 사용자 ID") Long userId
     );
+
+    @Operation(
+            summary = "앱 오픈 기록",
+            description = "앱 실행 시 호출하여 마지막 오픈 시각을 기록합니다. 마케팅 푸시 발송 대상 선정에 사용됩니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ApiResponse<Void> recordAppOpen(@Parameter(hidden = true) User user);
 }

--- a/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/users/facade/UserFacade.java
@@ -212,4 +212,12 @@ public class UserFacade {
     public void unblockUser(User user, Long userId) {
         userBlockService.unblock(user, userId);
     }
+
+    /**
+     * 앱 오픈 시각 기록 (마케팅 푸시 발송 대상 선정에 사용)
+     */
+    @Transactional
+    public void recordAppOpen(User user) {
+        userService.updateLastOpenedAt(user.getId());
+    }
 }

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/enums/NotificationType.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/enums/NotificationType.java
@@ -2,5 +2,6 @@ package com.nexters.sseotdabwa.domain.notifications.enums;
 
 public enum NotificationType {
     MY_FEED_CLOSED,            // 내가 올린 투표 종료
-    PARTICIPATED_FEED_CLOSED   // 내가 참여한 투표 종료
+    PARTICIPATED_FEED_CLOSED,  // 내가 참여한 투표 종료
+    MARKETING_NO_VOTE          // 투표 미등록 유저 마케팅 푸시
 }

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushScheduler.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushScheduler.java
@@ -1,0 +1,66 @@
+package com.nexters.sseotdabwa.domain.notifications.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import com.nexters.sseotdabwa.domain.notifications.enums.NotificationType;
+import com.nexters.sseotdabwa.domain.notifications.push.FcmSender;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+import com.nexters.sseotdabwa.domain.users.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketingPushScheduler {
+
+    private static final String MARKETING_TITLE = "살까, 말까 고민되는 거 있어요?";
+    private static final String MARKETING_BODY = "고민되는 아이템을 업로드해보세요!";
+    private static final int RECENT_DAYS = 7;
+
+    private final UserService userService;
+    private final FcmSender fcmSender;
+
+    // 매주 수요일 13:00 (KST)
+    @Scheduled(cron = "0 0 13 * * WED", zone = "Asia/Seoul")
+    public void sendMarketingPushWednesday() {
+        sendMarketingPush();
+    }
+
+    // 매주 토요일 13:00 (KST)
+    @Scheduled(cron = "0 0 13 * * SAT", zone = "Asia/Seoul")
+    public void sendMarketingPushSaturday() {
+        sendMarketingPush();
+    }
+
+    private void sendMarketingPush() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(RECENT_DAYS);
+        List<User> targets = userService.findMarketingTargets(cutoff);
+
+        if (targets.isEmpty()) {
+            log.info("[마케팅 푸시] 발송 대상 없음");
+            return;
+        }
+
+        log.info("[마케팅 푸시] 발송 시작. 대상 {}명", targets.size());
+
+        int successCount = 0;
+        for (User user : targets) {
+            try {
+                Map<String, String> data = Map.of("type", NotificationType.MARKETING_NO_VOTE.name());
+                fcmSender.send(user.getFcmToken(), MARKETING_TITLE, MARKETING_BODY, data);
+                successCount++;
+            } catch (Exception e) {
+                log.warn("[마케팅 푸시] FCM 전송 실패. userId={}", user.getId(), e);
+            }
+        }
+
+        log.info("[마케팅 푸시] 발송 완료. 성공={}/전체={}", successCount, targets.size());
+    }
+}

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushScheduler.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushScheduler.java
@@ -1,6 +1,7 @@
 package com.nexters.sseotdabwa.domain.notifications.scheduler;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ public class MarketingPushScheduler {
     private static final String MARKETING_TITLE = "살까, 말까 고민되는 거 있어요?";
     private static final String MARKETING_BODY = "고민되는 아이템을 업로드해보세요!";
     private static final int RECENT_DAYS = 7;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UserService userService;
     private final FcmSender fcmSender;
@@ -40,7 +42,7 @@ public class MarketingPushScheduler {
     }
 
     private void sendMarketingPush() {
-        LocalDateTime cutoff = LocalDateTime.now().minusDays(RECENT_DAYS);
+        LocalDateTime cutoff = LocalDateTime.now(KST).minusDays(RECENT_DAYS);
         List<User> targets = userService.findMarketingTargets(cutoff);
 
         if (targets.isEmpty()) {

--- a/src/main/java/com/nexters/sseotdabwa/domain/users/entity/User.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/users/entity/User.java
@@ -1,5 +1,7 @@
 package com.nexters.sseotdabwa.domain.users.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -53,6 +55,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean pushEnabled;
 
+    @Column
+    private LocalDateTime lastOpenedAt;
+
     @Builder
     public User(String socialId, String nickname, SocialAccount socialAccount,
             String profileImage, String email) {
@@ -79,6 +84,10 @@ public class User extends BaseEntity {
 
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = (fcmToken == null) ? null : fcmToken.trim();
+    }
+
+    public void updateLastOpenedAt() {
+        this.lastOpenedAt = LocalDateTime.now();
     }
 
     public boolean canReceivePush() {

--- a/src/main/java/com/nexters/sseotdabwa/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/users/repository/UserRepository.java
@@ -1,11 +1,15 @@
 package com.nexters.sseotdabwa.domain.users.repository;
 
-import com.nexters.sseotdabwa.domain.users.entity.User;
-import com.nexters.sseotdabwa.domain.users.enums.SocialAccount;
-
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.nexters.sseotdabwa.domain.users.entity.User;
+import com.nexters.sseotdabwa.domain.users.enums.SocialAccount;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -14,4 +18,22 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     List<User> findByIdIn(List<Long> ids);
+
+    /**
+     * 마케팅 푸시 발송 대상 조회
+     * - 최근 7일 내 앱 오픈
+     * - 투표를 한 번도 등록하지 않은 유저
+     * - pushEnabled = true, fcmToken 존재
+     */
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.lastOpenedAt >= :cutoff
+          AND u.pushEnabled = true
+          AND u.fcmToken IS NOT NULL
+          AND u.fcmToken <> ''
+          AND NOT EXISTS (
+              SELECT f FROM Feed f WHERE f.user = u
+          )
+    """)
+    List<User> findMarketingTargets(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/nexters/sseotdabwa/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/users/repository/UserRepository.java
@@ -30,7 +30,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
         WHERE u.lastOpenedAt >= :cutoff
           AND u.pushEnabled = true
           AND u.fcmToken IS NOT NULL
-          AND u.fcmToken <> ''
+          AND TRIM(u.fcmToken) <> ''
           AND NOT EXISTS (
               SELECT f FROM Feed f WHERE f.user = u
           )

--- a/src/main/java/com/nexters/sseotdabwa/domain/users/service/UserService.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/users/service/UserService.java
@@ -1,5 +1,6 @@
 package com.nexters.sseotdabwa.domain.users.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -146,5 +147,15 @@ public class UserService {
             return List.of();
         }
         return userRepository.findByIdIn(userIds);
+    }
+
+    @Transactional
+    public void updateLastOpenedAt(Long userId) {
+        User user = findById(userId);
+        user.updateLastOpenedAt();
+    }
+
+    public List<User> findMarketingTargets(LocalDateTime cutoff) {
+        return userRepository.findMarketingTargets(cutoff);
     }
 }

--- a/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/users/controller/UserControllerTest.java
@@ -597,4 +597,30 @@ class UserControllerTest {
         mockMvc.perform(post("/api/v1/users/blocks/{userId}", target.getId()))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("앱 오픈 기록 성공 - lastOpenedAt 갱신")
+    void recordAppOpen_success_updatesLastOpenedAt() throws Exception {
+        // given
+        User user = createUser();
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+
+        // when
+        mockMvc.perform(post("/api/v1/users/app-open")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"));
+
+        // then
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updated.getLastOpenedAt()).isNotNull();
+        assertThat(updated.getLastOpenedAt()).isAfter(LocalDateTime.now().minusMinutes(1));
+    }
+
+    @Test
+    @DisplayName("앱 오픈 기록 실패 - 비로그인 401")
+    void recordAppOpen_unauthorized_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/users/app-open"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/src/test/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushSchedulerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushSchedulerTest.java
@@ -49,7 +49,7 @@ class MarketingPushSchedulerTest {
                 eq("fcm_token_target"),
                 eq("살까, 말까 고민되는 거 있어요?"),
                 eq("고민되는 아이템을 업로드해보세요!"),
-                anyMap()
+                argThat(map -> "MARKETING_NO_VOTE".equals(map.get("type")))
         );
     }
 

--- a/src/test/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushSchedulerTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/domain/notifications/scheduler/MarketingPushSchedulerTest.java
@@ -1,0 +1,188 @@
+package com.nexters.sseotdabwa.domain.notifications.scheduler;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
+import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
+import com.nexters.sseotdabwa.domain.feeds.repository.FeedRepository;
+import com.nexters.sseotdabwa.domain.notifications.push.FcmSender;
+import com.nexters.sseotdabwa.domain.users.entity.User;
+import com.nexters.sseotdabwa.domain.users.enums.SocialAccount;
+import com.nexters.sseotdabwa.domain.users.repository.UserRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+class MarketingPushSchedulerTest {
+
+    @Autowired private MarketingPushScheduler marketingPushScheduler;
+    @Autowired private UserRepository userRepository;
+    @Autowired private FeedRepository feedRepository;
+
+    @MockBean private FcmSender fcmSender;
+
+    @Test
+    @DisplayName("투표 미등록 + 최근 7일 앱 오픈 유저에게 마케팅 푸시 발송")
+    void sendMarketingPush_sendsToEligibleUsers() throws Exception {
+        // given
+        User target = createUserWithToken("target");
+        setLastOpenedAt(target, LocalDateTime.now().minusDays(3));
+        userRepository.save(target);
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, times(1)).send(
+                eq("fcm_token_target"),
+                eq("살까, 말까 고민되는 거 있어요?"),
+                eq("고민되는 아이템을 업로드해보세요!"),
+                anyMap()
+        );
+    }
+
+    @Test
+    @DisplayName("7일 초과 비활성 유저는 발송 제외")
+    void sendMarketingPush_excludesInactiveUsers() throws Exception {
+        // given
+        User inactive = createUserWithToken("inactive");
+        setLastOpenedAt(inactive, LocalDateTime.now().minusDays(8));
+        userRepository.save(inactive);
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("lastOpenedAt이 null인 유저는 발송 제외")
+    void sendMarketingPush_excludesUsersWithNullLastOpenedAt() {
+        // given
+        User user = createUserWithToken("nullopen");
+        // lastOpenedAt = null (기본값)
+        userRepository.save(user);
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("피드를 등록한 유저는 발송 제외")
+    void sendMarketingPush_excludesUsersWithFeeds() throws Exception {
+        // given
+        User userWithFeed = createUserWithToken("hasfeed");
+        setLastOpenedAt(userWithFeed, LocalDateTime.now().minusDays(1));
+        userRepository.save(userWithFeed);
+
+        feedRepository.save(Feed.builder()
+                .user(userWithFeed)
+                .content("이미 투표 등록함")
+                .price(10000L)
+                .category(FeedCategory.FASHION)
+                .build());
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("pushEnabled=false 유저는 발송 제외")
+    void sendMarketingPush_excludesPushDisabledUsers() throws Exception {
+        // given
+        User user = createUserWithToken("pushdisabled");
+        setLastOpenedAt(user, LocalDateTime.now().minusDays(1));
+        setPushEnabled(user, false);
+        userRepository.save(user);
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("fcmToken이 없는 유저는 발송 제외")
+    void sendMarketingPush_excludesUsersWithoutToken() throws Exception {
+        // given
+        User user = createUser("notoken");
+        setLastOpenedAt(user, LocalDateTime.now().minusDays(1));
+        // fcmToken = null
+        userRepository.save(user);
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, never()).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("발송 대상 다수 - 각 유저에게 개별 발송")
+    void sendMarketingPush_sendsToMultipleTargets() throws Exception {
+        // given
+        for (int i = 0; i < 3; i++) {
+            User user = createUserWithToken("multi" + i);
+            setLastOpenedAt(user, LocalDateTime.now().minusDays(1));
+            userRepository.save(user);
+        }
+
+        // when
+        marketingPushScheduler.sendMarketingPushWednesday();
+
+        // then
+        verify(fcmSender, times(3)).send(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    // ---------------- helpers ----------------
+
+    private User createUser(String prefix) {
+        return userRepository.save(User.builder()
+                .socialId(UUID.randomUUID().toString())
+                .nickname(prefix + "_" + UUID.randomUUID().toString().substring(0, 6))
+                .socialAccount(SocialAccount.KAKAO)
+                .build());
+    }
+
+    private User createUserWithToken(String prefix) {
+        User user = User.builder()
+                .socialId(UUID.randomUUID().toString())
+                .nickname(prefix + "_" + UUID.randomUUID().toString().substring(0, 6))
+                .socialAccount(SocialAccount.KAKAO)
+                .build();
+        user.updateFcmToken("fcm_token_" + prefix);
+        return userRepository.save(user);
+    }
+
+    private void setLastOpenedAt(User user, LocalDateTime value) throws Exception {
+        Field field = User.class.getDeclaredField("lastOpenedAt");
+        field.setAccessible(true);
+        field.set(user, value);
+    }
+
+    private void setPushEnabled(User user, boolean value) throws Exception {
+        Field field = User.class.getDeclaredField("pushEnabled");
+        field.setAccessible(true);
+        field.set(user, value);
+    }
+}


### PR DESCRIPTION
### 🚀 Issue Number
#128 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#128-push-marketing` → `develop`

### 🔎 작업 내용
- 앱 오픈 시각 기록 API 추가
  - `User` 엔티티에 `lastOpenedAt` 필드 추가
  - `POST /api/v1/users/app-open` 엔드포인트 추가
  - 앱 실행 시 클라이언트가 호출하여 마지막 오픈 시각 갱신
- 투표 미등록 유저 마케팅 푸시 스케줄러 구현
  - 발송 대상: 최근 7일 내 앱 오픈 + 투표를 한 번도 등록하지 않은 유저
  - 제외 조건: `pushEnabled = false`, FCM 토큰 없는 유저
  - 발송 시간: 매주 수요일 / 토요일 13:00 (KST)
  - 알림 내용: `살까, 말까 고민되는 거 있어요?` / `고민되는 아이템을 업로드해보세요!`
  - `NotificationType.MARKETING_NO_VOTE` 추가
  - DB 저장 없이 FCM 푸시만 발송 (피드와 무관한 마케팅 알림)

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|--------------|------|
| `UserControllerTest.java` | ✅ Pass |
| `MarketingPushSchedulerTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 앱 열기 기록을 남기는 새 API가 추가되었습니다.
  * 사용자의 마지막 앱 실행 시각을 저장하고 조회하는 기능이 추가되었습니다.
  * 수요일과 토요일 오후 1시에 마케팅 푸시를 자동 발송합니다.
  * 새로운 마케팅 푸시 유형이 추가되었습니다.

* **Bug Fixes**
  * 알림 유형 목록의 누락된 구분자가 정리되었습니다.

* **Tests**
  * 앱 열기 기록 API와 마케팅 푸시 발송 대상 조건에 대한 테스트가 추가되었습니다.

* **Documentation**
  * README의 커버리지 수치가 최신 값으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->