### PR TITLE
[FEATURE] #129 투표 마일스톤 알림 구현 (1명·10명 참여, 종료 title 개선)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.8%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-83.1%25-brightgreen)
 # Sseotdabwa-BE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-82.5%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-82.8%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
@@ -39,8 +39,10 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class NotificationFacade {
 
-    private static final String FEED_CLOSED_TITLE = "투표 종료!";
     private static final String FEED_CLOSED_BODY = "토봉이가 결과를 들고 기다리고 있어요.";
+    private static final String VOTED_1_BODY = "첫 투표가 도착했어요.";
+    private static final String VOTED_10_BODY = "벌써 10명이나 투표에 참여했어요!";
+    private static final int FEED_TITLE_MAX_LENGTH = 10;
 
     private final NotificationService notificationService;
     private final FeedService feedService;
@@ -153,12 +155,43 @@ public class NotificationFacade {
         }
     }
 
+    /**
+     * 투표 발생 시 작성자에게 마일스톤 알림 (1명, 10명)
+     * - guest 투표는 호출하지 않음 (VoteFacade에서 필터링)
+     */
+    @Transactional
+    public void onVoteCreated(Feed feed) {
+        long total = (feed.getYesCount() == null ? 0L : feed.getYesCount())
+                   + (feed.getNoCount() == null ? 0L : feed.getNoCount());
+
+        if (total != 1L && total != 10L) return;
+
+        User author = feed.getUser();
+        NotificationType type;
+        String title;
+        String body;
+
+        if (total == 1L) {
+            type = NotificationType.MY_FEED_VOTED_1;
+            title = buildVotedTitle(feed.getTitle(), 1);
+            body = VOTED_1_BODY;
+        } else {
+            type = NotificationType.MY_FEED_VOTED_10;
+            title = buildVotedTitle(feed.getTitle(), 10);
+            body = VOTED_10_BODY;
+        }
+
+        Notification notification = notificationService.createIfAbsent(author, feed, type, title, body);
+        pushBestEffort(author, notification, feed, type);
+    }
+
     private void notifyFeedClosed(Feed feed) {
         User author = feed.getUser();
+        String closedTitle = buildClosedTitle(feed.getTitle());
 
         // 1) 작성자 알림
         Notification authorNoti = notificationService.createIfAbsent(
-                author, feed, NotificationType.MY_FEED_CLOSED, FEED_CLOSED_TITLE, FEED_CLOSED_BODY
+                author, feed, NotificationType.MY_FEED_CLOSED, closedTitle, FEED_CLOSED_BODY
         );
         pushBestEffort(author, authorNoti, feed, NotificationType.MY_FEED_CLOSED);
 
@@ -176,7 +209,7 @@ public class NotificationFacade {
 
         for (User u : participants) {
             Notification saved = notificationService.createIfAbsent(
-                    u, feed, NotificationType.PARTICIPATED_FEED_CLOSED, FEED_CLOSED_TITLE, FEED_CLOSED_BODY
+                    u, feed, NotificationType.PARTICIPATED_FEED_CLOSED, closedTitle, FEED_CLOSED_BODY
             );
             pushBestEffort(u, saved, feed, NotificationType.PARTICIPATED_FEED_CLOSED);
         }
@@ -197,7 +230,7 @@ public class NotificationFacade {
             data.put("feedId", String.valueOf(feed.getId()));
             data.put("type", type.name());
 
-            fcmSender.send(user.getFcmToken(), FEED_CLOSED_TITLE, FEED_CLOSED_BODY, data);
+            fcmSender.send(user.getFcmToken(), notification.getTitle(), notification.getBody(), data);
 //            log.info("FCM 전송 성공 userId={}, token={}", user.getId(), user.getFcmToken());
         } catch (Exception e) {
             log.warn("FCM 전송 실패 (best-effort). userId={}, feedId={}, type={}",
@@ -236,6 +269,21 @@ public class NotificationFacade {
         String label = yesWin ? "YES" : "NO";
 
         return new NotificationResultCommand(percent, label);
+    }
+
+    private String truncateTitle(String title) {
+        if (!StringUtils.hasText(title)) return "";
+        return title.length() > FEED_TITLE_MAX_LENGTH
+                ? title.substring(0, FEED_TITLE_MAX_LENGTH) + ".."
+                : title;
+    }
+
+    private String buildVotedTitle(String feedTitle, int count) {
+        return "'" + truncateTitle(feedTitle) + "' 투표 " + count + "명 참여!";
+    }
+
+    private String buildClosedTitle(String feedTitle) {
+        return "'" + truncateTitle(feedTitle) + "' 투표 종료!";
     }
 
     /**

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
@@ -10,6 +10,7 @@ import com.nexters.sseotdabwa.common.exception.GlobalException;
 import com.nexters.sseotdabwa.api.notifications.exception.NotificationErrorCode;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nexters.sseotdabwa.api.notifications.dto.NotificationResponse;
@@ -158,8 +159,9 @@ public class NotificationFacade {
     /**
      * 투표 발생 시 작성자에게 마일스톤 알림 (1명, 10명)
      * - guest 투표는 호출하지 않음 (VoteFacade에서 필터링)
+     * - REQUIRES_NEW: vote() 트랜잭션과 분리해 알림 실패가 투표 커밋에 영향을 주지 않도록
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onVoteCreated(Feed feed) {
         long total = (feed.getYesCount() == null ? 0L : feed.getYesCount())
                    + (feed.getNoCount() == null ? 0L : feed.getNoCount());

--- a/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
@@ -14,9 +14,11 @@ import com.nexters.sseotdabwa.domain.votes.service.VoteLogService;
 import com.nexters.sseotdabwa.domain.votes.service.command.VoteCreateCommand;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class VoteFacade {
@@ -49,7 +51,11 @@ public class VoteFacade {
         VoteCreateCommand command = new VoteCreateCommand(user, feed, choice, VoteType.USER);
         voteLogService.createVoteLog(command);
 
-        notificationFacade.onVoteCreated(feed);
+        try {
+            notificationFacade.onVoteCreated(feed);
+        } catch (Exception e) {
+            log.warn("마일스톤 알림 실패 (best-effort). feedId={}", feedId, e);
+        }
 
         return VoteResponse.of(feed, choice, user.getProfileImage());
     }

--- a/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
@@ -1,5 +1,6 @@
 package com.nexters.sseotdabwa.api.votes.facade;
 
+import com.nexters.sseotdabwa.api.notifications.facade.NotificationFacade;
 import com.nexters.sseotdabwa.api.votes.dto.VoteRequest;
 import com.nexters.sseotdabwa.api.votes.dto.VoteResponse;
 import com.nexters.sseotdabwa.common.exception.GlobalException;
@@ -22,6 +23,7 @@ public class VoteFacade {
 
     private final FeedService feedService;
     private final VoteLogService voteLogService;
+    private final NotificationFacade notificationFacade;
 
     @Transactional
     public VoteResponse vote(User user, Long feedId, VoteRequest request) {
@@ -46,6 +48,8 @@ public class VoteFacade {
 
         VoteCreateCommand command = new VoteCreateCommand(user, feed, choice, VoteType.USER);
         voteLogService.createVoteLog(command);
+
+        notificationFacade.onVoteCreated(feed);
 
         return VoteResponse.of(feed, choice, user.getProfileImage());
     }

--- a/src/main/java/com/nexters/sseotdabwa/domain/notifications/enums/NotificationType.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/notifications/enums/NotificationType.java
@@ -3,5 +3,7 @@ package com.nexters.sseotdabwa.domain.notifications.enums;
 public enum NotificationType {
     MY_FEED_CLOSED,            // 내가 올린 투표 종료
     PARTICIPATED_FEED_CLOSED,  // 내가 참여한 투표 종료
+    MY_FEED_VOTED_1,           // 내가 올린 투표 1명 참여
+    MY_FEED_VOTED_10,          // 내가 올린 투표 10명 참여
     MARKETING_NO_VOTE          // 투표 미등록 유저 마케팅 푸시
 }

--- a/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
@@ -24,12 +24,14 @@ import com.nexters.sseotdabwa.domain.votes.enums.VoteChoice;
 import com.nexters.sseotdabwa.domain.votes.enums.VoteType;
 import com.nexters.sseotdabwa.domain.votes.repository.VoteLogRepository;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +52,17 @@ class NotificationFacadeTest {
 
     @MockBean
     private FcmSender fcmSender;
+
+    @AfterEach
+    void cleanup() {
+        if (!TestTransaction.isActive()) {
+            notificationRepository.deleteAll();
+            voteLogRepository.deleteAll();
+            feedImageRepository.deleteAll();
+            feedRepository.deleteAll();
+            userRepository.deleteAll();
+        }
+    }
 
     @Test
     @DisplayName("피드 마감 처리 시 작성자/참여자 알림이 생성된다")
@@ -229,12 +242,13 @@ class NotificationFacadeTest {
     @Test
     @DisplayName("1번째 투표 시 MY_FEED_VOTED_1 알림 생성")
     void onVoteCreated_creates_voted1_notification_on_first_vote() throws Exception {
-        // given
+        // given - REQUIRES_NEW가 참조할 수 있도록 선커밋
         User author = createUser("author");
         Feed feed = createFeedWithTitle(author, "크록스0123456");
-
-        // yesCount = 1 세팅
         feed.incrementYes();
+        feedRepository.save(feed);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
         // when
         notificationFacade.onVoteCreated(feed);
@@ -247,12 +261,13 @@ class NotificationFacadeTest {
     @Test
     @DisplayName("10번째 투표 시 MY_FEED_VOTED_10 알림 생성")
     void onVoteCreated_creates_voted10_notification_on_tenth_vote() throws Exception {
-        // given
+        // given - REQUIRES_NEW가 참조할 수 있도록 선커밋
         User author = createUser("author");
         Feed feed = createFeedWithTitle(author, "크록스0123456");
-
-        // yesCount = 10 세팅
         for (int i = 0; i < 10; i++) feed.incrementYes();
+        feedRepository.save(feed);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
         // when
         notificationFacade.onVoteCreated(feed);
@@ -281,10 +296,13 @@ class NotificationFacadeTest {
     @Test
     @DisplayName("같은 마일스톤 알림은 중복 생성 안 함")
     void onVoteCreated_does_not_duplicate_same_milestone() {
-        // given
+        // given - REQUIRES_NEW가 참조할 수 있도록 선커밋
         User author = createUser("author");
         Feed feed = createFeedWithTitle(author, "테스트피드");
         feed.incrementYes();
+        feedRepository.save(feed);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
         notificationFacade.onVoteCreated(feed);
 

--- a/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacadeTest.java
@@ -224,6 +224,122 @@ class NotificationFacadeTest {
         assertThat(count).isZero();
     }
 
+    // ===== onVoteCreated =====
+
+    @Test
+    @DisplayName("1번째 투표 시 MY_FEED_VOTED_1 알림 생성")
+    void onVoteCreated_creates_voted1_notification_on_first_vote() throws Exception {
+        // given
+        User author = createUser("author");
+        Feed feed = createFeedWithTitle(author, "크록스0123456");
+
+        // yesCount = 1 세팅
+        feed.incrementYes();
+
+        // when
+        notificationFacade.onVoteCreated(feed);
+
+        // then
+        assertThat(notificationRepository.existsByUserIdAndFeedIdAndType(
+                author.getId(), feed.getId(), NotificationType.MY_FEED_VOTED_1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("10번째 투표 시 MY_FEED_VOTED_10 알림 생성")
+    void onVoteCreated_creates_voted10_notification_on_tenth_vote() throws Exception {
+        // given
+        User author = createUser("author");
+        Feed feed = createFeedWithTitle(author, "크록스0123456");
+
+        // yesCount = 10 세팅
+        for (int i = 0; i < 10; i++) feed.incrementYes();
+
+        // when
+        notificationFacade.onVoteCreated(feed);
+
+        // then
+        assertThat(notificationRepository.existsByUserIdAndFeedIdAndType(
+                author.getId(), feed.getId(), NotificationType.MY_FEED_VOTED_10)).isTrue();
+    }
+
+    @Test
+    @DisplayName("1명, 10명 외 투표 수에서는 알림 생성 안 함")
+    void onVoteCreated_does_not_create_notification_for_other_counts() {
+        // given
+        User author = createUser("author");
+        Feed feed = createFeedWithTitle(author, "테스트피드");
+
+        for (int i = 0; i < 5; i++) feed.incrementYes();
+
+        // when
+        notificationFacade.onVoteCreated(feed);
+
+        // then
+        assertThat(notificationRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("같은 마일스톤 알림은 중복 생성 안 함")
+    void onVoteCreated_does_not_duplicate_same_milestone() {
+        // given
+        User author = createUser("author");
+        Feed feed = createFeedWithTitle(author, "테스트피드");
+        feed.incrementYes();
+
+        notificationFacade.onVoteCreated(feed);
+
+        // when - 같은 조건으로 재호출
+        notificationFacade.onVoteCreated(feed);
+
+        // then
+        assertThat(notificationRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("투표 종료 알림 title에 피드 제목이 포함된다")
+    void onFeedsClosed_title_includes_feed_title() {
+        // given
+        User author = createUser("author");
+        author.updateFcmToken("fcm_token_test");
+        userRepository.save(author);
+
+        Feed feed = createFeedWithTitle(author, "크록스0123456");
+        createFeedImage(feed);
+
+        // when
+        notificationFacade.onFeedsClosed(List.of(feed.getId()));
+
+        // then
+        Notification notification = notificationRepository
+                .findAll().stream()
+                .filter(n -> n.getType() == NotificationType.MY_FEED_CLOSED)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(notification.getTitle()).isEqualTo("'크록스0123456' 투표 종료!");
+    }
+
+    @Test
+    @DisplayName("피드 제목이 10자 초과면 truncate 처리된다")
+    void onFeedsClosed_title_truncates_long_feed_title() {
+        // given
+        User author = createUser("author");
+        Feed feed = createFeedWithTitle(author, "12345678901234567890");
+        createFeedImage(feed);
+
+        // when
+        notificationFacade.onFeedsClosed(List.of(feed.getId()));
+
+        // then
+        Notification notification = notificationRepository
+                .findAll().stream()
+                .filter(n -> n.getType() == NotificationType.MY_FEED_CLOSED)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(notification.getTitle()).isEqualTo("'1234567890..' 투표 종료!");
+    }
+
     // ---------------- helpers ----------------
 
     private User createUser(String prefix) {
@@ -240,6 +356,16 @@ class NotificationFacadeTest {
                 .content("테스트 피드")
                 .price(10000L)
                 .category(FeedCategory.FASHION)
+                .build());
+    }
+
+    private Feed createFeedWithTitle(User user, String title) {
+        return feedRepository.save(Feed.builder()
+                .user(user)
+                .content("테스트 피드")
+                .price(10000L)
+                .category(FeedCategory.FASHION)
+                .title(title)
                 .build());
     }
 

--- a/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
@@ -3,10 +3,12 @@ package com.nexters.sseotdabwa.api.votes.facade;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nexters.sseotdabwa.api.votes.dto.VoteRequest;
@@ -21,6 +23,7 @@ import com.nexters.sseotdabwa.domain.users.entity.User;
 import com.nexters.sseotdabwa.domain.users.enums.SocialAccount;
 import com.nexters.sseotdabwa.domain.users.repository.UserRepository;
 import com.nexters.sseotdabwa.domain.votes.enums.VoteChoice;
+import com.nexters.sseotdabwa.domain.votes.repository.VoteLogRepository;
 
 import jakarta.persistence.EntityManager;
 
@@ -44,7 +47,20 @@ class VoteFacadeTest {
     private NotificationRepository notificationRepository;
 
     @Autowired
+    private VoteLogRepository voteLogRepository;
+
+    @Autowired
     private EntityManager entityManager;
+
+    @AfterEach
+    void cleanup() {
+        if (!TestTransaction.isActive()) {
+            notificationRepository.deleteAll();
+            voteLogRepository.deleteAll();
+            feedRepository.deleteAll();
+            userRepository.deleteAll();
+        }
+    }
 
     // ===== 회원 투표 =====
 
@@ -196,10 +212,12 @@ class VoteFacadeTest {
     @Test
     @DisplayName("회원 투표 1번째 - MY_FEED_VOTED_1 알림 생성")
     void vote_first_creates_voted1_notification() {
-        // given
+        // given - REQUIRES_NEW가 참조할 수 있도록 선커밋
         User owner = createUser();
         User voter = createUser();
         Feed feed = createFeed(owner);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
         // when
         voteFacade.vote(voter, feed.getId(), new VoteRequest(VoteChoice.YES));
@@ -212,9 +230,11 @@ class VoteFacadeTest {
     @Test
     @DisplayName("회원 투표 10번째 - MY_FEED_VOTED_10 알림 생성")
     void vote_tenth_creates_voted10_notification() {
-        // given
+        // given - REQUIRES_NEW가 참조할 수 있도록 선커밋
         User owner = createUser();
         Feed feed = createFeed(owner);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
         // 9명 투표 (게스트로 카운트만 채움)
         for (int i = 0; i < 9; i++) {

--- a/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
+++ b/src/test/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacadeTest.java
@@ -15,6 +15,8 @@ import com.nexters.sseotdabwa.common.exception.GlobalException;
 import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
 import com.nexters.sseotdabwa.domain.feeds.enums.FeedCategory;
 import com.nexters.sseotdabwa.domain.feeds.repository.FeedRepository;
+import com.nexters.sseotdabwa.domain.notifications.enums.NotificationType;
+import com.nexters.sseotdabwa.domain.notifications.repository.NotificationRepository;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 import com.nexters.sseotdabwa.domain.users.enums.SocialAccount;
 import com.nexters.sseotdabwa.domain.users.repository.UserRepository;
@@ -37,6 +39,9 @@ class VoteFacadeTest {
 
     @Autowired
     private FeedRepository feedRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
 
     @Autowired
     private EntityManager entityManager;
@@ -184,6 +189,59 @@ class VoteFacadeTest {
         assertThatThrownBy(() -> voteFacade.guestVote(feed.getId(), request))
                 .isInstanceOf(GlobalException.class)
                 .hasMessage("마감된 피드에는 투표할 수 없습니다.");
+    }
+
+    // ===== 마일스톤 알림 =====
+
+    @Test
+    @DisplayName("회원 투표 1번째 - MY_FEED_VOTED_1 알림 생성")
+    void vote_first_creates_voted1_notification() {
+        // given
+        User owner = createUser();
+        User voter = createUser();
+        Feed feed = createFeed(owner);
+
+        // when
+        voteFacade.vote(voter, feed.getId(), new VoteRequest(VoteChoice.YES));
+
+        // then
+        assertThat(notificationRepository.existsByUserIdAndFeedIdAndType(
+                owner.getId(), feed.getId(), NotificationType.MY_FEED_VOTED_1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원 투표 10번째 - MY_FEED_VOTED_10 알림 생성")
+    void vote_tenth_creates_voted10_notification() {
+        // given
+        User owner = createUser();
+        Feed feed = createFeed(owner);
+
+        // 9명 투표 (게스트로 카운트만 채움)
+        for (int i = 0; i < 9; i++) {
+            voteFacade.guestVote(feed.getId(), new VoteRequest(VoteChoice.YES));
+        }
+
+        // when - 10번째 투표 (회원)
+        User voter = createUser();
+        voteFacade.vote(voter, feed.getId(), new VoteRequest(VoteChoice.YES));
+
+        // then
+        assertThat(notificationRepository.existsByUserIdAndFeedIdAndType(
+                owner.getId(), feed.getId(), NotificationType.MY_FEED_VOTED_10)).isTrue();
+    }
+
+    @Test
+    @DisplayName("게스트 투표는 알림을 생성하지 않는다")
+    void guestVote_does_not_create_notification() {
+        // given
+        User owner = createUser();
+        Feed feed = createFeed(owner);
+
+        // when
+        voteFacade.guestVote(feed.getId(), new VoteRequest(VoteChoice.YES));
+
+        // then
+        assertThat(notificationRepository.count()).isZero();
     }
 
     // ===== 48시간 만료 검증 =====


### PR DESCRIPTION
### 🚀 Issue Number
#129 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`feature/#129-feed-noti` → `develop`

### 🔎 작업 내용
- 투표 마일스톤 알림 신규 구현 (1명·10명 참여)
  - `NotificationType`에 `MY_FEED_VOTED_1`, `MY_FEED_VOTED_10` 추가
  - `NotificationFacade.onVoteCreated(Feed feed)` 메서드 추가
    - 총 투표 수(yesCount + noCount)가 1 또는 10인 경우에만 알림 생성
    - 피드 제목 truncate 처리 (10자 초과 시 앞 10자 + `..`)
    - `notificationService.createIfAbsent()`로 중복 방지 후 FCM 푸시
  - `VoteFacade.vote()` — 투표 저장 완료 후 `onVoteCreated()` 호출
    - `guestVote()`는 호출하지 않음
- 종료 알림 title 포맷 개선
  - `NotificationFacade.notifyFeedClosed()` title 포맷 변경
  - AS-IS: `"투표 종료!"` → TO-BE: `"'{피드 제목}' 투표 종료!"`
  - 피드 제목 truncate 처리 동일 적용
- `pushBestEffort()` 버그 수정: 하드코딩 title/body → `notification.getTitle()` / `notification.getBody()` 사용

| 알림 | title | body |
|------|-------|------|
| 1명 참여 | `'{피드 제목}' 투표 1명 참여!` | 첫 투표가 도착했어요. |
| 10명 참여 | `'{피드 제목}' 투표 10명 참여!` | 벌써 10명이나 투표에 참여했어요! |
| 종료 | `'{피드 제목}' 투표 종료!` | 토봉이가 결과를 들고 기다리고 있어요. |

### 🎯 테스트 결과
| 테스트 클래스 | 결과 |
|-------------|------|
| `VoteFacadeTest.java` | ✅ Pass |
| `NotificationFacadeTest.java` | ✅ Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 투표 참여자가 1명 또는 10명에 도달하면 작성자에게 마일스톤 알림을 보냅니다.
  - 피드 마감 및 투표 관련 알림에 피드 제목이 포함되며, 긴 제목은 자동으로 축약됩니다.
  - 알림 유형에 맞는 제목과 본문이 정확히 표시됩니다.
  - 게스트 투표에는 알림이 생성되지 않습니다.

- **문서**
  - README의 테스트 커버리지 배지를 82.8%로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->