### PR TITLE
[FIX] #132 투표 알림 Lock wait timeout 수정 - AFTER_COMMIT 이벤트 방식으로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-83.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-13.1%25-red)
 # Sseotdabwa-BE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-![Coverage](https://img.shields.io/badge/coverage-13.1%25-red)
+![Coverage](https://img.shields.io/badge/coverage-82.9%25-brightgreen)
 # Sseotdabwa-BE

--- a/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/notifications/facade/NotificationFacade.java
@@ -12,6 +12,8 @@ import com.nexters.sseotdabwa.api.notifications.exception.NotificationErrorCode;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.nexters.sseotdabwa.api.notifications.dto.NotificationResponse;
 import com.nexters.sseotdabwa.common.config.AwsProperties;
@@ -26,6 +28,7 @@ import com.nexters.sseotdabwa.domain.notifications.service.NotificationService;
 import com.nexters.sseotdabwa.domain.notifications.service.command.NotificationResultCommand;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 import com.nexters.sseotdabwa.domain.users.service.UserService;
+import com.nexters.sseotdabwa.domain.votes.event.VoteCreatedEvent;
 import com.nexters.sseotdabwa.domain.votes.service.VoteLogService;
 
 import lombok.RequiredArgsConstructor;
@@ -157,9 +160,17 @@ public class NotificationFacade {
     }
 
     /**
+     * vote() 커밋 후 이벤트로 호출 — feed X-Lock 해제 후 실행되므로 FK 락 충돌 없음
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleVoteCreated(VoteCreatedEvent event) {
+        onVoteCreated(event.feed());
+    }
+
+    /**
      * 투표 발생 시 작성자에게 마일스톤 알림 (1명, 10명)
      * - guest 투표는 호출하지 않음 (VoteFacade에서 필터링)
-     * - REQUIRES_NEW: vote() 트랜잭션과 분리해 알림 실패가 투표 커밋에 영향을 주지 않도록
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onVoteCreated(Feed feed) {

--- a/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
+++ b/src/main/java/com/nexters/sseotdabwa/api/votes/facade/VoteFacade.java
@@ -1,6 +1,5 @@
 package com.nexters.sseotdabwa.api.votes.facade;
 
-import com.nexters.sseotdabwa.api.notifications.facade.NotificationFacade;
 import com.nexters.sseotdabwa.api.votes.dto.VoteRequest;
 import com.nexters.sseotdabwa.api.votes.dto.VoteResponse;
 import com.nexters.sseotdabwa.common.exception.GlobalException;
@@ -9,12 +8,14 @@ import com.nexters.sseotdabwa.domain.feeds.service.FeedService;
 import com.nexters.sseotdabwa.domain.users.entity.User;
 import com.nexters.sseotdabwa.domain.votes.enums.VoteChoice;
 import com.nexters.sseotdabwa.domain.votes.enums.VoteType;
+import com.nexters.sseotdabwa.domain.votes.event.VoteCreatedEvent;
 import com.nexters.sseotdabwa.domain.votes.exception.VoteErrorCode;
 import com.nexters.sseotdabwa.domain.votes.service.VoteLogService;
 import com.nexters.sseotdabwa.domain.votes.service.command.VoteCreateCommand;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +26,7 @@ public class VoteFacade {
 
     private final FeedService feedService;
     private final VoteLogService voteLogService;
-    private final NotificationFacade notificationFacade;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public VoteResponse vote(User user, Long feedId, VoteRequest request) {
@@ -51,11 +52,7 @@ public class VoteFacade {
         VoteCreateCommand command = new VoteCreateCommand(user, feed, choice, VoteType.USER);
         voteLogService.createVoteLog(command);
 
-        try {
-            notificationFacade.onVoteCreated(feed);
-        } catch (Exception e) {
-            log.warn("마일스톤 알림 실패 (best-effort). feedId={}", feedId, e);
-        }
+        eventPublisher.publishEvent(new VoteCreatedEvent(feed));
 
         return VoteResponse.of(feed, choice, user.getProfileImage());
     }

--- a/src/main/java/com/nexters/sseotdabwa/domain/votes/event/VoteCreatedEvent.java
+++ b/src/main/java/com/nexters/sseotdabwa/domain/votes/event/VoteCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.nexters.sseotdabwa.domain.votes.event;
+
+import com.nexters.sseotdabwa.domain.feeds.entity.Feed;
+
+public record VoteCreatedEvent(Feed feed) {}


### PR DESCRIPTION
### 🚀 Issue Number
#132 

### 🧰 PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
`fix/#132-lock-timeout` → `develop`

### 🔎 작업 내용
- 투표 시 알림 저장에서 Lock wait timeout 발생하는 버그 수정
  - **원인**: `vote()`가 `feeds` 행에 Pessimistic X-Lock을 잡은 채 `REQUIRES_NEW` 트랜잭션이 시작되면,
    notification INSERT 시 FK 체크가 같은 `feeds` 행에 S-Lock을 요청 → 데드락 → 타임아웃 (MySQL 1205)
  - **해결**: `@TransactionalEventListener(AFTER_COMMIT)` 방식으로 전환
    - `vote()` 트랜잭션이 완전히 커밋되어 X-Lock이 해제된 후 이벤트 발동
    - `VoteCreatedEvent` 레코드 추가
    - `VoteFacade`: `NotificationFacade` 직접 호출 제거 → `ApplicationEventPublisher.publishEvent()` 로 변경
    - `NotificationFacade`: `handleVoteCreated()` 이벤트 핸들러 추가 (`AFTER_COMMIT` + `REQUIRES_NEW`)

## 🎯 테스트 결과

| 테스트 클래스 | 결과 |
|-------------|------|
| `VoteFacadeTest.java` | ✅ Pass |
| `NotificationFacadeTest.java` | ✅ Pass |

## 📌 DB 적용 필요

prod 배포 전 아래 쿼리 실행 필요 (`notifications.type` 컬럼 ENUM → VARCHAR 변환)
```sql
ALTER TABLE notifications MODIFY COLUMN type VARCHAR(40) NOT NULL;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 투표가 정상적으로 완료된 후 피드 작성자에게 알림이 안정적으로 전달됩니다.
  - 투표 처리와 알림 전송이 분리되어, 알림 처리 중에도 투표 결과가 정상 반영됩니다.

- **문서**
  - README의 테스트 커버리지 배지 표시가 `82.9%`로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->